### PR TITLE
g3fcgen: fix deb package release

### DIFF
--- a/g3fcgen/debian/g3fcgen.install
+++ b/g3fcgen/debian/g3fcgen.install
@@ -1,3 +1,2 @@
 usr/bin/g3fcgen
 lib/systemd/system/
-lib/systemd/system-preset/


### PR DESCRIPTION
![image](https://github.com/bytedance/g3/assets/1736119/7cf68611-d8a1-4e7c-81f2-e5ea13909a53)
