### PR TITLE
restore support of openssl 1.1

### DIFF
--- a/doc/dev-setup.md
+++ b/doc/dev-setup.md
@@ -192,10 +192,10 @@ ln -s /usr/pkg/bin/python3.10 /usr/pkg/bin/python3
 
 For *g3proxy*:
 ```text
-openssl >= 3.0.0
-c-ares >= 1.12.0
+openssl
+c-ares
 lua
-python3 >= 3.7
+python3
 ```
 
 ## Development Tools

--- a/doc/dev-setup.md
+++ b/doc/dev-setup.md
@@ -192,10 +192,10 @@ ln -s /usr/pkg/bin/python3.10 /usr/pkg/bin/python3
 
 For *g3proxy*:
 ```text
-openssl
-c-ares
+openssl >= 1.1.1
+c-ares >= 1.12.0
 lua
-python3
+python3 >= 3.7
 ```
 
 ## Development Tools

--- a/g3tiles/src/config/server/openssl_proxy/host.rs
+++ b/g3tiles/src/config/server/openssl_proxy/host.rs
@@ -81,7 +81,7 @@ impl OpensslHostConfig {
 
             let mut store_builder = X509StoreBuilder::new()
                 .map_err(|e| anyhow!("failed to create ca cert store builder: {e}"))?;
-            let mut ca_stack =
+            let mut subject_stack =
                 Stack::new().map_err(|e| anyhow!("failed to get new ca name stack: {e}"))?;
 
             if self.client_auth_certs.is_empty() {
@@ -91,15 +91,15 @@ impl OpensslHostConfig {
             } else {
                 for (i, cert) in self.client_auth_certs.iter().enumerate() {
                     let ca_cert = X509::from_der(cert.as_slice()).unwrap();
-                    store_builder
-                        .add_cert(ca_cert)
-                        .map_err(|e| anyhow!("[#{i}] failed to add ca certificate: {e}"))?;
-                    let name = ca_cert
+                    let subject = ca_cert
                         .subject_name()
                         .to_owned()
                         .map_err(|e| anyhow!("[#{i}] failed to get ca subject name: {e}"))?;
-                    ca_stack
-                        .push(name)
+                    store_builder
+                        .add_cert(ca_cert)
+                        .map_err(|e| anyhow!("[#{i}] failed to add ca certificate: {e}"))?;
+                    subject_stack
+                        .push(subject)
                         .map_err(|e| anyhow!("[#{i}] failed to push to ca name stack: {e}"))?;
                 }
             }
@@ -108,8 +108,8 @@ impl OpensslHostConfig {
             ssl_builder
                 .set_verify_cert_store(store)
                 .map_err(|e| anyhow!("failed to set ca certs: {e}"))?;
-            if !ca_stack.is_empty() {
-                ssl_builder.set_client_ca_list(ca_stack);
+            if !subject_stack.is_empty() {
+                ssl_builder.set_client_ca_list(subject_stack);
             }
         } else {
             ssl_builder.set_verify(SslVerifyMode::NONE);

--- a/lib/openssl-async-job/build.rs
+++ b/lib/openssl-async-job/build.rs
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2023 ByteDance and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use std::env;
+
+#[allow(clippy::unusual_byte_groupings)]
+fn main() {
+    if let Ok(version) = env::var("DEP_OPENSSL_VERSION_NUMBER") {
+        let version = u64::from_str_radix(&version, 16).unwrap();
+
+        if version >= 0x3_00_00_00_0 {
+            println!("cargo:rustc-cfg=ossl300");
+        }
+    }
+}

--- a/lib/openssl-async-job/src/ffi.rs
+++ b/lib/openssl-async-job/src/ffi.rs
@@ -25,6 +25,7 @@ pub enum ASYNC_JOB {}
 pub enum ASYNC_WAIT_CTX {}
 
 #[allow(non_camel_case_types)]
+#[cfg(ossl300)]
 pub type ASYNC_callback_fn = Option<unsafe extern "C" fn(arg: *mut c_void) -> c_int>;
 
 pub const ASYNC_ERR: c_int = 0;
@@ -91,16 +92,20 @@ extern "C" {
         numdelfds: *mut usize,
     ) -> c_int;
     pub fn ASYNC_WAIT_CTX_clear_fd(ctx: *mut ASYNC_WAIT_CTX, key: *const c_void) -> c_int;
+    #[cfg(ossl300)]
     pub fn ASYNC_WAIT_CTX_get_callback(
         ctx: *mut ASYNC_WAIT_CTX,
         callback: *mut ASYNC_callback_fn,
         callback_arg: *mut *mut c_void,
     ) -> c_int;
+    #[cfg(ossl300)]
     pub fn ASYNC_WAIT_CTX_set_callback(
         ctx: *mut ASYNC_WAIT_CTX,
         callback: ASYNC_callback_fn,
         callback_arg: *mut c_void,
     ) -> c_int;
+    #[cfg(ossl300)]
     pub fn ASYNC_WAIT_CTX_set_status(ctx: *mut ASYNC_WAIT_CTX, status: c_int) -> c_int;
+    #[cfg(ossl300)]
     pub fn ASYNC_WAIT_CTX_get_status(ctx: *mut ASYNC_WAIT_CTX) -> c_int;
 }

--- a/lib/openssl-async-job/src/task.rs
+++ b/lib/openssl-async-job/src/task.rs
@@ -19,11 +19,13 @@ use std::future::Future;
 use std::io;
 use std::os::fd::RawFd;
 use std::pin::Pin;
+#[cfg(ossl300)]
 use std::sync::Arc;
 use std::task::{ready, Context, Poll};
 use std::{mem, ptr};
 
 use anyhow::anyhow;
+#[cfg(ossl300)]
 use atomic_waker::AtomicWaker;
 use libc::{c_int, c_void};
 use openssl::error::ErrorStack;
@@ -64,6 +66,7 @@ struct Action<T: AsyncOperation> {
 pub struct OpensslAsyncTask<T: AsyncOperation> {
     job: *mut ffi::ASYNC_JOB,
     wait_ctx: AsyncWaitCtx, // should be dropped before atomic_waker
+    #[cfg(ossl300)]
     atomic_waker: Arc<AtomicWaker>,
     action: Box<UnsafeCell<Action<T>>>,
 }
@@ -73,6 +76,20 @@ pub struct OpensslAsyncTask<T: AsyncOperation> {
 unsafe impl<T: AsyncOperation + Send> Send for OpensslAsyncTask<T> {}
 
 impl<T: AsyncOperation> OpensslAsyncTask<T> {
+    #[cfg(not(ossl300))]
+    pub(crate) fn new(operation: T) -> Result<Self, ErrorStack> {
+        let wait_ctx = AsyncWaitCtx::new()?;
+        Ok(OpensslAsyncTask {
+            job: ptr::null_mut(),
+            wait_ctx,
+            action: Box::new(UnsafeCell::new(Action {
+                operation,
+                result: Err(anyhow!("not run yet")),
+            })),
+        })
+    }
+
+    #[cfg(ossl300)]
     pub(crate) fn new(operation: T) -> Result<Self, ErrorStack> {
         let atomic_waker = Arc::new(AtomicWaker::new());
         let wait_ctx = AsyncWaitCtx::new()?;
@@ -88,6 +105,56 @@ impl<T: AsyncOperation> OpensslAsyncTask<T> {
         })
     }
 
+    #[cfg(not(ossl300))]
+    fn poll_run(&mut self, cx: &mut Context<'_>) -> Poll<Result<T::Output, OpensslAsyncTaskError>> {
+        let mut ret: c_int = 0;
+
+        loop {
+            let mut param = self.action.get();
+            let r = unsafe {
+                ffi::ASYNC_start_job(
+                    &mut self.job,
+                    self.wait_ctx.as_ptr(),
+                    &mut ret,
+                    Some(start_job::<T>),
+                    &mut param as *mut _ as *mut c_void,
+                    mem::size_of::<*mut Action<T>>(),
+                )
+            };
+
+            match r {
+                ffi::ASYNC_ERR => return Poll::Ready(Err(ErrorStack::get().into())),
+                ffi::ASYNC_NO_JOBS => {
+                    // no available jobs, yield now and wake later
+                    cx.waker().wake_by_ref();
+                    return Poll::Pending;
+                }
+                ffi::ASYNC_PAUSE => {
+                    let action = unsafe { &mut *self.action.get() };
+                    let (add, del) = self.wait_ctx.get_changed_fds()?;
+                    for fd in add {
+                        action.operation.track_raw_fd(fd)?;
+                    }
+                    for fd in del {
+                        action.operation.untrack_raw_fd(fd);
+                    }
+                    ready!(action.operation.poll_ready_fds(cx))?;
+                }
+                ffi::ASYNC_FINISH => {
+                    let action = unsafe { &mut *self.action.get() };
+                    let r = mem::replace(&mut action.result, Err(anyhow!("")));
+                    return Poll::Ready(r.map_err(OpensslAsyncTaskError::Operation));
+                }
+                r => {
+                    return Poll::Ready(Err(OpensslAsyncTaskError::Unexpected(format!(
+                        "ASYNC_start_job returned {r}"
+                    ))));
+                }
+            }
+        }
+    }
+
+    #[cfg(ossl300)]
     fn poll_run(&mut self, cx: &mut Context<'_>) -> Poll<Result<T::Output, OpensslAsyncTaskError>> {
         let mut ret: c_int = 0;
 

--- a/lib/openssl-async-job/src/wait_ctx.rs
+++ b/lib/openssl-async-job/src/wait_ctx.rs
@@ -16,10 +16,8 @@
 
 use std::os::fd::RawFd;
 use std::ptr;
-use std::sync::Arc;
 
-use atomic_waker::AtomicWaker;
-use libc::{c_int, c_void};
+use libc::c_int;
 use openssl::error::ErrorStack;
 use openssl::foreign_types::foreign_type;
 
@@ -100,25 +98,42 @@ impl AsyncWaitCtx {
             del_fds.into_iter().map(RawFd::from).collect(),
         ))
     }
+}
 
-    pub fn set_callback(&self, waker: &Arc<AtomicWaker>) -> Result<(), ErrorStack> {
-        let r = unsafe {
-            ffi::ASYNC_WAIT_CTX_set_callback(self.0, Some(wake), Arc::as_ptr(waker) as *mut c_void)
-        };
-        if r != 1 {
-            Err(ErrorStack::get())
-        } else {
-            Ok(())
+#[cfg(ossl300)]
+mod ossl3 {
+    use std::sync::Arc;
+
+    use atomic_waker::AtomicWaker;
+    use libc::{c_int, c_void};
+    use openssl::error::ErrorStack;
+
+    use super::{ffi, AsyncWaitCtx};
+
+    impl AsyncWaitCtx {
+        pub fn set_callback(&self, waker: &Arc<AtomicWaker>) -> Result<(), ErrorStack> {
+            let r = unsafe {
+                ffi::ASYNC_WAIT_CTX_set_callback(
+                    self.0,
+                    Some(wake),
+                    Arc::as_ptr(waker) as *mut c_void,
+                )
+            };
+            if r != 1 {
+                Err(ErrorStack::get())
+            } else {
+                Ok(())
+            }
+        }
+
+        pub fn get_callback_status(&self) -> c_int {
+            unsafe { ffi::ASYNC_WAIT_CTX_get_status(self.0) }
         }
     }
 
-    pub fn get_callback_status(&self) -> c_int {
-        unsafe { ffi::ASYNC_WAIT_CTX_get_status(self.0) }
+    extern "C" fn wake(arg: *mut c_void) -> c_int {
+        let waker = unsafe { &*(arg as *const AtomicWaker) };
+        waker.wake();
+        0
     }
-}
-
-extern "C" fn wake(arg: *mut c_void) -> c_int {
-    let waker = unsafe { &*(arg as *const AtomicWaker) };
-    waker.wake();
-    0
 }

--- a/scripts/package/detect_openssl_feature.sh
+++ b/scripts/package/detect_openssl_feature.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-if $(pkg-config --atleast-version 3.0.0 libssl)
+if $(pkg-config --atleast-version 1.1.1 libssl)
 then
 	:
 else


### PR DESCRIPTION
The performance of Openssl 3.2 is really poor in our benchmark test (12000 vs 45000).
Restore to 1.1.1 when possible.
See https://github.com/openssl/openssl/issues/17627.