### PR TITLE
fix: clone missing submodules before build tarball

### DIFF
--- a/scripts/release/build_tarball.sh
+++ b/scripts/release/build_tarball.sh
@@ -45,8 +45,9 @@ echo "==> Use temp build dir ${BUILD_DIR}"
 echo "==> cleaning local cargo checkouts"
 cargo cache --autoclean
 
-
+ 
 echo "==> adding source code from git"
+git submodule update --init --recursive
 git archive --format=tar --prefix="${SOURCE_NAME}-${PKG_VERSION}/" "${GIT_REVISION}" | tar -C "${BUILD_DIR}" -xf -
 git submodule foreach "
     echo \"--> adding source code for submodule \${name}\"


### PR DESCRIPTION
fixes release/build_tarball.sh script from a clean repo
`==> adding incorporating source for BoringSSL
python3: can't open file '/tmp/build.g3proxy-1.7.35.Xql/g3proxy-1.7.35/third_party/boringssl/util/generate_build_files.py': [Errno 2] No such file or directory
clear temp build dir /tmp/build.g3proxy-1.7.35.Xql`