### PR TITLE
g3proxy: add option for setting fwmark for tcp listener.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 
 # IDE
 .idea/
+.vscode/
 
 # Cargo
 /target/

--- a/g3proxy/doc/configuration/values/network.rst
+++ b/g3proxy/doc/configuration/values/network.rst
@@ -223,6 +223,13 @@ It consists of the following fields:
     If the backlog argument is greater than the value in /proc/sys/net/core/somaxconn, then it is silently truncated
     to that value. Since Linux 5.4, the default in this file is 4096; in earlier kernels, the default value is 128.
 
+* netfilter_mark
+
+  **optional**, **type**: unsigned int
+
+  Set the netfilter mark (SOL_SOCKET, SO_MARK) value for the listening socket. If this field not present,
+  the mark value will not be touch. This value can be used for advanced routing policy or netfilter rules.
+
 * ipv6_only
 
   **optional**, **type**: bool

--- a/lib/g3-socket/src/tcp.rs
+++ b/lib/g3-socket/src/tcp.rs
@@ -39,6 +39,10 @@ pub fn new_std_listener(config: &TcpListenConfig) -> io::Result<std::net::TcpLis
     if config.transparent() {
         socket.set_ip_transparent(true)?;
     }
+    #[cfg(any(target_os = "android", target_os = "fuchsia", target_os = "linux"))]
+    if let Some(mark) = config.mark() {
+        socket.set_mark(mark)?;
+    }
     let bind_addr: SockAddr = addr.into();
     socket.bind(&bind_addr)?;
     socket.listen(config.backlog() as i32)?;

--- a/lib/g3-types/src/net/tcp/listen.rs
+++ b/lib/g3-types/src/net/tcp/listen.rs
@@ -28,6 +28,8 @@ pub struct TcpListenConfig {
     ipv6only: bool,
     #[cfg(target_os = "linux")]
     transparent: bool,
+    #[cfg(any(target_os = "android", target_os = "fuchsia", target_os = "linux"))]
+    mark: Option<u32>,
     backlog: u32,
     instance: usize,
     scale: usize,
@@ -40,6 +42,8 @@ impl Default for TcpListenConfig {
             ipv6only: false,
             #[cfg(target_os = "linux")]
             transparent: false,
+            #[cfg(any(target_os = "android", target_os = "fuchsia", target_os = "linux"))]
+            mark: None,
             backlog: DEFAULT_LISTEN_BACKLOG,
             instance: 1,
             scale: 0,
@@ -72,6 +76,12 @@ impl TcpListenConfig {
         self.transparent
     }
 
+    #[cfg(any(target_os = "android", target_os = "fuchsia", target_os = "linux"))]
+    #[inline]
+    pub fn mark(&self) -> Option<u32> {
+        self.mark
+    }
+
     #[inline]
     pub fn backlog(&self) -> u32 {
         self.backlog
@@ -98,8 +108,15 @@ impl TcpListenConfig {
     }
 
     #[cfg(target_os = "linux")]
+    #[inline]
     pub fn set_transparent(&mut self) {
         self.transparent = true;
+    }
+
+    #[cfg(any(target_os = "android", target_os = "fuchsia", target_os = "linux"))]
+    #[inline]
+    pub fn set_mark(&mut self, mark: u32) {
+        self.mark = Some(mark);
     }
 
     #[inline]

--- a/lib/g3-yaml/src/value/net/tcp.rs
+++ b/lib/g3-yaml/src/value/net/tcp.rs
@@ -109,6 +109,13 @@ pub fn as_tcp_listen_config(value: &Yaml) -> anyhow::Result<TcpListenConfig> {
                     config.set_instance(instance);
                     Ok(())
                 }
+                #[cfg(any(target_os = "android", target_os = "fuchsia", target_os = "linux"))]
+                "netfilter_mark" | "fwmark" | "mark" => {
+                    let mark = crate::value::as_u32(v)
+                        .context(format!("invalid u32 value for key {k}"))?;
+                    config.set_mark(mark);
+                    Ok(())
+                }
                 "scale" => set_tcp_listen_scale(&mut config, v)
                     .context(format!("invalid scale value for key {k}")),
                 _ => Err(anyhow!("invalid key {k}")),


### PR DESCRIPTION
Add a option for setting the fwmark of tcp listener.
This fwmark may used in some advanced routing policy or netfilter rules.