### PR TITLE
Allow hostnames in config

### DIFF
--- a/lib/g3-yaml/src/value/net/tcp.rs
+++ b/lib/g3-yaml/src/value/net/tcp.rs
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-use std::net::SocketAddr;
 use std::str::FromStr;
 
 use anyhow::{anyhow, Context};
@@ -77,9 +76,9 @@ pub fn as_tcp_listen_config(value: &Yaml) -> anyhow::Result<TcpListenConfig> {
             let port = u16::try_from(*i).map_err(|e| anyhow!("out of range u16 value: {e}"))?;
             config.set_port(port);
         }
-        Yaml::String(s) => {
-            let addr =
-                SocketAddr::from_str(s).map_err(|e| anyhow!("invalid socket address: {e}"))?;
+        Yaml::String(_) => {
+            let addr = crate::value::as_sockaddr(value)
+                .map_err(|e| anyhow!("invalid socket address: {}", e))?;
             config.set_socket_address(addr);
         }
         Yaml::Hash(map) => {

--- a/lib/g3-yaml/src/value/net/udp.rs
+++ b/lib/g3-yaml/src/value/net/udp.rs
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-use std::net::SocketAddr;
 use std::str::FromStr;
 
 use anyhow::{anyhow, Context};
@@ -109,9 +108,9 @@ pub fn as_udp_listen_config(value: &Yaml) -> anyhow::Result<UdpListenConfig> {
             let port = u16::try_from(*i).map_err(|e| anyhow!("out of range u16 value: {e}"))?;
             config.set_port(port);
         }
-        Yaml::String(s) => {
-            let addr =
-                SocketAddr::from_str(s).map_err(|e| anyhow!("invalid socket address: {e}"))?;
+        Yaml::String(_) => {
+            let addr = crate::value::as_sockaddr(value)
+                .map_err(|e| anyhow!("invalid socket address: {}", e))?;
             config.set_socket_address(addr);
         }
         Yaml::Hash(map) => {


### PR DESCRIPTION
This PR changes the g3-yaml crate to do DNS resolution, making it possible to specify hostnames in the config. This is needed to allow g3 to stream its udpdump traffic to a host (via `host.docker.internal`) when running in Docker.

This is also useful in other deployments when hostnames are more convenient than ips.

Resolves #180 