### PR TITLE
Support to use mimic cert when generate fake cert

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3532,9 +3532,9 @@ dependencies = [
 
 [[package]]
 name = "variant-ssl"
-version = "0.14.0"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1da9f6902cc09df62c80cb1b8e680e3005f5bd65243e4607d8ad94050cb8cb7"
+checksum = "0843f5dab9b00f53b2645de5ab38db442ab907776882b2877573465f060506fc"
 dependencies = [
  "bitflags 2.5.0",
  "cfg-if",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -145,7 +145,7 @@ pin-project = "1.1"
 #
 rustls = "0.21.5"
 tokio-rustls = "0.24"
-openssl = { package = "variant-ssl", version = "0.14.0" }
+openssl = { package = "variant-ssl", version = "0.14.2" }
 openssl-sys = { package = "variant-ssl-sys", version = "0.13.0" }
 openssl-probe = "0.1"
 rustls-pemfile = "1.0"

--- a/g3fcgen/src/frontend/mod.rs
+++ b/g3fcgen/src/frontend/mod.rs
@@ -14,75 +14,18 @@
  * limitations under the License.
  */
 
-use anyhow::{anyhow, Context};
-use rmpv::ValueRef;
-
 mod stats;
 pub(crate) use stats::FrontendStats;
 
 mod udp_dgram;
 pub(crate) use udp_dgram::UdpDgramFrontend;
 
+mod request;
+pub(crate) use request::Request;
+
 #[derive(Debug)]
-pub(crate) struct ResponseData {
-    pub(crate) host: String,
+pub(crate) struct GeneratedData {
     pub(crate) cert: String,
     pub(crate) key: String,
     pub(crate) ttl: u32,
-}
-
-impl ResponseData {
-    pub(crate) fn encode(&self) -> anyhow::Result<Vec<u8>> {
-        let map = vec![
-            (
-                ValueRef::String("host".into()),
-                ValueRef::String(self.host.as_str().into()),
-            ),
-            (
-                ValueRef::String("cert".into()),
-                ValueRef::String(self.cert.as_str().into()),
-            ),
-            (
-                ValueRef::String("key".into()),
-                ValueRef::String(self.key.as_str().into()),
-            ),
-            (
-                ValueRef::String("ttl".into()),
-                ValueRef::Integer(self.ttl.into()),
-            ),
-        ];
-        let mut buf = Vec::with_capacity(32);
-        let v = ValueRef::Map(map);
-        rmpv::encode::write_value_ref(&mut buf, &v)
-            .map_err(|e| anyhow!("msgpack encode failed: {e}"))?;
-        Ok(buf)
-    }
-}
-
-pub(crate) fn decode_req(mut data: &[u8]) -> anyhow::Result<String> {
-    let v =
-        rmpv::decode::read_value_ref(&mut data).map_err(|e| anyhow!("invalid req data: {e}"))?;
-
-    if let ValueRef::Map(map) = v {
-        let mut host = String::default();
-
-        for (k, v) in map {
-            let key = g3_msgpack::value::as_string(&k)?;
-            match g3_msgpack::key::normalize(key.as_str()).as_str() {
-                "host" => {
-                    host = g3_msgpack::value::as_string(&v)
-                        .context(format!("invalid string value for key {key}"))?;
-                }
-                _ => return Err(anyhow!("invalid key {key}")),
-            }
-        }
-
-        if host.is_empty() {
-            Err(anyhow!("invalid host value"))
-        } else {
-            Ok(host)
-        }
-    } else {
-        Err(anyhow!("the req root data type should be map"))
-    }
 }

--- a/g3fcgen/src/frontend/request.rs
+++ b/g3fcgen/src/frontend/request.rs
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2024 ByteDance and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use std::sync::Arc;
+
+use anyhow::{anyhow, Context};
+use openssl::x509::X509;
+use rmpv::ValueRef;
+
+use g3_types::net::TlsServiceType;
+
+use super::GeneratedData;
+
+pub(crate) struct Request {
+    pub(crate) host: Arc<str>,
+    service: TlsServiceType,
+    pub(crate) cert: Option<X509>,
+}
+
+impl Request {
+    pub(crate) fn parse_req(mut data: &[u8]) -> anyhow::Result<Self> {
+        let v = rmpv::decode::read_value_ref(&mut data)
+            .map_err(|e| anyhow!("invalid req data: {e}"))?;
+
+        if let ValueRef::Map(map) = v {
+            let mut host = String::default();
+            let mut service = TlsServiceType::Http;
+            let mut cert = None;
+
+            for (k, v) in map {
+                let key = g3_msgpack::value::as_string(&k)?;
+                match g3_msgpack::key::normalize(key.as_str()).as_str() {
+                    "host" => {
+                        host = g3_msgpack::value::as_string(&v)
+                            .context(format!("invalid string value for key {key}"))?;
+                    }
+                    "service" => {
+                        service = g3_msgpack::value::as_tls_service_type(&v)
+                            .context(format!("invalid tls service type value for key {key}"))?;
+                    }
+                    "cert" => {
+                        let certs = g3_msgpack::value::as_openssl_certificates(&v)
+                            .context(format!("invalid mimic cert value for key {key}"))?;
+                        cert = certs.into_iter().next();
+                    }
+                    _ => return Err(anyhow!("invalid key {key}")),
+                }
+            }
+
+            if host.is_empty() {
+                return Err(anyhow!("invalid host value"));
+            }
+            Ok(Request {
+                host: Arc::from(host),
+                service,
+                cert,
+            })
+        } else {
+            Err(anyhow!("the req root data type should be map"))
+        }
+    }
+
+    pub(crate) fn encode_rsp(&self, generated: &GeneratedData) -> anyhow::Result<Vec<u8>> {
+        let map = vec![
+            (
+                ValueRef::String("host".into()),
+                ValueRef::String(self.host.as_ref().into()),
+            ),
+            (
+                ValueRef::String("service".into()),
+                ValueRef::String(self.service.as_str().into()),
+            ),
+            (
+                ValueRef::String("cert".into()),
+                ValueRef::String(generated.cert.as_str().into()),
+            ),
+            (
+                ValueRef::String("key".into()),
+                ValueRef::String(generated.key.as_str().into()),
+            ),
+            (
+                ValueRef::String("ttl".into()),
+                ValueRef::Integer(generated.ttl.into()),
+            ),
+        ];
+        let mut buf = Vec::with_capacity(4096);
+        let v = ValueRef::Map(map);
+        rmpv::encode::write_value_ref(&mut buf, &v)
+            .map_err(|e| anyhow!("msgpack encode failed: {e}"))?;
+        Ok(buf)
+    }
+}

--- a/g3proxy/doc/protocol/helper/cert_generator.rst
+++ b/g3proxy/doc/protocol/helper/cert_generator.rst
@@ -28,6 +28,26 @@ host
 
 Set the hostname of the target tls server. May be a domain or an IP address.
 
+service
+-------
+
+**optional**, **type**: string
+
+Set the tls service type. It should be returned in response.
+
+**default**: http
+
+.. versionadded:: 1.9.0
+
+cert
+----
+
+**optional**, **type**: string
+
+The real upstream cert.
+
+.. versionadded:: 1.9.0
+
 response
 ========
 
@@ -37,6 +57,17 @@ host
 **required**, **type**: string
 
 The hostname as specified in the request.
+
+service
+-------
+
+**optional**, **type**: string
+
+Set the tls service type. It should be the same value as in the request.
+
+**default**: http
+
+.. versionadded:: 1.9.0
 
 cert
 ----

--- a/lib/g3-io-ext/src/cache/mod.rs
+++ b/lib/g3-io-ext/src/cache/mod.rs
@@ -68,6 +68,7 @@ impl<R> EffectiveCacheData<R> {
 
 pub struct CacheQueryRequest<K, R> {
     cache_key: Arc<K>,
+    query_cache_only: bool,
     notifier: oneshot::Sender<Arc<EffectiveCacheData<R>>>,
 }
 

--- a/lib/g3-io-ext/src/cache/runtime.rs
+++ b/lib/g3-io-ext/src/cache/runtime.rs
@@ -117,7 +117,7 @@ impl<K: Hash + Eq, R: Send + Sync> EffectiveCacheRuntime<K, R> {
                     }
                 }
             }
-        } else {
+        } else if !req.query_cache_only {
             match self.doing.entry(Arc::clone(&req.cache_key)) {
                 hash_map::Entry::Occupied(mut o) => {
                     o.get_mut().push(Some(req));

--- a/lib/g3-msgpack/src/value/mod.rs
+++ b/lib/g3-msgpack/src/value/mod.rs
@@ -17,6 +17,7 @@
 mod datetime;
 mod metrics;
 mod primary;
+mod tls;
 mod uuid;
 
 #[cfg(feature = "openssl")]
@@ -29,6 +30,7 @@ pub use self::uuid::as_uuid;
 pub use datetime::as_rfc3339_datetime;
 pub use metrics::{as_metrics_name, as_weighted_metrics_name};
 pub use primary::{as_f64, as_string, as_u32, as_weighted_name_string};
+pub use tls::as_tls_service_type;
 
 pub use openssl::{as_openssl_certificates, as_openssl_private_key};
 

--- a/lib/g3-msgpack/src/value/tls.rs
+++ b/lib/g3-msgpack/src/value/tls.rs
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2024 ByteDance and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use std::str::FromStr;
+
+use anyhow::anyhow;
+use rmpv::ValueRef;
+
+use g3_types::net::TlsServiceType;
+
+pub fn as_tls_service_type(v: &ValueRef) -> anyhow::Result<TlsServiceType> {
+    match v {
+        ValueRef::String(s) => {
+            if let Some(s) = s.as_str() {
+                TlsServiceType::from_str(s)
+                    .map_err(|e| anyhow!("invalid tls service type string: {e}"))
+            } else {
+                Err(anyhow!("invalid utf-8 string"))
+            }
+        }
+        ValueRef::Binary(b) => {
+            let s =
+                std::str::from_utf8(b).map_err(|e| anyhow!("invalid utf-8 string buffer: {e}"))?;
+            TlsServiceType::from_str(s).map_err(|e| anyhow!("invalid tls service type string: {e}"))
+        }
+        _ => Err(anyhow!(
+            "msgpack value type for 'tls service type' should be 'binary' or 'string'"
+        )),
+    }
+}

--- a/lib/g3-types/src/net/tls/mod.rs
+++ b/lib/g3-types/src/net/tls/mod.rs
@@ -19,3 +19,6 @@ pub use alpn::{AlpnProtocol, TlsAlpn};
 
 mod server_name;
 pub use server_name::TlsServerName;
+
+mod service_type;
+pub use service_type::TlsServiceType;

--- a/lib/g3-types/src/net/tls/service_type.rs
+++ b/lib/g3-types/src/net/tls/service_type.rs
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2024 ByteDance and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use std::fmt;
+use std::str::FromStr;
+
+#[derive(Clone, Copy, Debug, Hash, Eq, PartialEq)]
+pub enum TlsServiceType {
+    Http,
+    Smtp,
+}
+
+impl TlsServiceType {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            TlsServiceType::Http => "http",
+            TlsServiceType::Smtp => "smtp",
+        }
+    }
+}
+
+impl fmt::Display for TlsServiceType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+pub struct InvalidServiceType;
+
+impl fmt::Display for InvalidServiceType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("unsupported tls service type")
+    }
+}
+
+impl FromStr for TlsServiceType {
+    type Err = InvalidServiceType;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "http" | "HTTP" => Ok(TlsServiceType::Http),
+            "smtp" | "SMTP" => Ok(TlsServiceType::Smtp),
+            _ => Err(InvalidServiceType),
+        }
+    }
+}


### PR DESCRIPTION
Close https://github.com/bytedance/g3/issues/172
Only Subject and SubjectAlternativeName fields are copied by now, which is needed for proper SMTP support.