### PR TITLE
allow to use static socket address in config file

### DIFF
--- a/g3proxy/doc/configuration/values/network.rst
+++ b/g3proxy/doc/configuration/values/network.rst
@@ -14,12 +14,26 @@ sockaddr str
 
 The string should be in *<ip>[:<port>]* format, in which the port may be omitted if a default value is available.
 
+.. _conf_value_static_sockaddr_str:
+
+static sockaddr str
+===================
+
+**yaml value**: str
+
+The string should be in *@<domain>:<port>* or *@<ip>:<port>* format.
+
+It is different from :ref:`upstream str <conf_value_upstream_str>` as:
+
+- It will be resolved when we load the config files
+- The domain is only allowed to be resolved to just 1 IP address
+
 .. _conf_value_env_sockaddr_str:
 
 env sockaddr str
 ================
 
-**yaml value**: :ref:`sockaddr str <conf_value_sockaddr_str>` or :ref:`env var <conf_value_env_var>`
+**yaml value**: :ref:`sockaddr str <conf_value_sockaddr_str>` or :ref:`static sockaddr str <conf_value_static_sockaddr_str>` or :ref:`env var <conf_value_env_var>`
 
 The string should be in *<ip>[:<port>]* format, in which the port may be omitted if a default value is available.
 

--- a/lib/g3-yaml/src/value/net/tcp.rs
+++ b/lib/g3-yaml/src/value/net/tcp.rs
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-use std::net::SocketAddr;
 use std::str::FromStr;
 
 use anyhow::{anyhow, Context};
@@ -77,9 +76,9 @@ pub fn as_tcp_listen_config(value: &Yaml) -> anyhow::Result<TcpListenConfig> {
             let port = u16::try_from(*i).map_err(|e| anyhow!("out of range u16 value: {e}"))?;
             config.set_port(port);
         }
-        Yaml::String(s) => {
-            let addr =
-                SocketAddr::from_str(s).map_err(|e| anyhow!("invalid socket address: {e}"))?;
+        Yaml::String(_) => {
+            let addr = crate::value::as_env_sockaddr(value)
+                .context("invalid tcp listen socket address value")?;
             config.set_socket_address(addr);
         }
         Yaml::Hash(map) => {

--- a/lib/g3-yaml/src/value/net/udp.rs
+++ b/lib/g3-yaml/src/value/net/udp.rs
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-use std::net::SocketAddr;
 use std::str::FromStr;
 
 use anyhow::{anyhow, Context};
@@ -109,9 +108,9 @@ pub fn as_udp_listen_config(value: &Yaml) -> anyhow::Result<UdpListenConfig> {
             let port = u16::try_from(*i).map_err(|e| anyhow!("out of range u16 value: {e}"))?;
             config.set_port(port);
         }
-        Yaml::String(s) => {
-            let addr =
-                SocketAddr::from_str(s).map_err(|e| anyhow!("invalid socket address: {e}"))?;
+        Yaml::String(_) => {
+            let addr = crate::value::as_env_sockaddr(value)
+                .context("invalid udp listen socket address value")?;
             config.set_socket_address(addr);
         }
         Yaml::Hash(map) => {


### PR DESCRIPTION
Close https://github.com/bytedance/g3/issues/180
Close https://github.com/bytedance/g3/pull/181

Now you can set the conf value to @host.docker.internal:1234 as long as the domain host.docker.internal only resolves to just one IP address