### PR TITLE
add link to lts 1.8 branch

### DIFF
--- a/doc/long-term_support.md
+++ b/doc/long-term_support.md
@@ -13,7 +13,7 @@ You can ask for commercial support if you need a longer support time.
 
 # Current LTS branches
 
-## g3proxy-v1.8
+## [g3proxy-v1.8](https://github.com/bytedance/g3/tree/lts/g3proxy/1.8/default)
 
 Long-Term branch for [g3proxy](../g3proxy) 1.8.x.
 


### PR DESCRIPTION
It took me a while to understand where the LTS could be found. This link might help others in future to find it faster.