### PR TITLE
turn ProtocolInspectPolicy into AclDstHostRuleSet

### DIFF
--- a/g3proxy/doc/configuration/values/dpi.rst
+++ b/g3proxy/doc/configuration/values/dpi.rst
@@ -67,11 +67,12 @@ The keys ars:
 protocol inspect policy
 -----------------------
 
-**type**: string
+**type**: string | map
 
 Set what we should do to a specific application protocol.
 
-The possible value are:
+One can use the *string* type to define an action for any upstream traffic, regardless of the host,
+the possible values for this are:
 
 - intercept
 
@@ -89,7 +90,11 @@ The possible value are:
 
   Block the traffic. And we will try to send application level error code to the client.
 
-.. versionadded:: 1.9.0
+For more complex setups one can also use the *map* type which
+is documented in :ref:`acl rule set <conf_value_acl_rule_set>` with the only
+difference that the action variants are the strings defined here.
+
+.. versionadded:: 1.11.0
 
 .. _conf_value_dpi_protocol_inspection:
 

--- a/g3proxy/src/audit/handle.rs
+++ b/g3proxy/src/audit/handle.rs
@@ -113,8 +113,8 @@ impl AuditHandle {
     }
 
     #[inline]
-    pub(crate) fn h2_inspect_policy(&self) -> ProtocolInspectPolicy {
-        self.auditor_config.h2_inspect_policy
+    pub(crate) fn h2_inspect_policy(&self) -> &ProtocolInspectPolicy {
+        &self.auditor_config.h2_inspect_policy
     }
 
     #[inline]
@@ -123,13 +123,13 @@ impl AuditHandle {
     }
 
     #[inline]
-    pub(crate) fn websocket_inspect_policy(&self) -> ProtocolInspectPolicy {
-        self.auditor_config.websocket_inspect_policy
+    pub(crate) fn websocket_inspect_policy(&self) -> &ProtocolInspectPolicy {
+        &self.auditor_config.websocket_inspect_policy
     }
 
     #[inline]
-    pub(crate) fn smtp_inspect_policy(&self) -> ProtocolInspectPolicy {
-        self.auditor_config.smtp_inspect_policy
+    pub(crate) fn smtp_inspect_policy(&self) -> &ProtocolInspectPolicy {
+        &self.auditor_config.smtp_inspect_policy
     }
 
     #[inline]
@@ -138,8 +138,8 @@ impl AuditHandle {
     }
 
     #[inline]
-    pub(crate) fn imap_inspect_policy(&self) -> ProtocolInspectPolicy {
-        self.auditor_config.imap_inspect_policy
+    pub(crate) fn imap_inspect_policy(&self) -> &ProtocolInspectPolicy {
+        &self.auditor_config.imap_inspect_policy
     }
 
     #[inline]

--- a/g3proxy/src/auth/user.rs
+++ b/g3proxy/src/auth/user.rs
@@ -27,7 +27,7 @@ use governor::{clock::DefaultClock, state::InMemoryState, state::NotKeyed, RateL
 use tokio::time::Instant;
 
 use g3_io_ext::{GlobalDatagramLimiter, GlobalLimitGroup, GlobalStreamLimiter};
-use g3_types::acl::{AclAction, AclNetworkRule};
+use g3_types::acl::{AclAction, AclNetworkRule, ActionContract};
 use g3_types::acl_set::AclDstHostRuleSet;
 use g3_types::auth::UserAuthError;
 use g3_types::limit::{GaugeSemaphore, GaugeSemaphorePermit};
@@ -605,7 +605,7 @@ impl User {
                 forbid_stats.add_dest_denied();
                 return action;
             };
-            default_action = default_action.restrict(action);
+            default_action = default_action.restrict(&action);
         }
 
         if let Some(filter) = &self.dst_host_filter {
@@ -614,7 +614,7 @@ impl User {
                 forbid_stats.add_dest_denied();
                 return action;
             }
-            default_action = default_action.restrict(action);
+            default_action = default_action.restrict(&action);
         }
 
         if default_action.forbid_early() {
@@ -636,7 +636,7 @@ impl User {
                         forbid_stats.add_ua_blocked();
                         return Some(action);
                     }
-                    default_action = default_action.restrict(action);
+                    default_action = default_action.restrict(&action);
                 }
             }
             Some(default_action)

--- a/g3proxy/src/auth/user.rs
+++ b/g3proxy/src/auth/user.rs
@@ -27,7 +27,7 @@ use governor::{clock::DefaultClock, state::InMemoryState, state::NotKeyed, RateL
 use tokio::time::Instant;
 
 use g3_io_ext::{GlobalDatagramLimiter, GlobalLimitGroup, GlobalStreamLimiter};
-use g3_types::acl::{AclAction, AclNetworkRule, ActionContract};
+use g3_types::acl::{AclAction, AclNetworkRule};
 use g3_types::acl_set::AclDstHostRuleSet;
 use g3_types::auth::UserAuthError;
 use g3_types::limit::{GaugeSemaphore, GaugeSemaphorePermit};
@@ -605,7 +605,7 @@ impl User {
                 forbid_stats.add_dest_denied();
                 return action;
             };
-            default_action = default_action.restrict(&action);
+            default_action = default_action.restrict(action);
         }
 
         if let Some(filter) = &self.dst_host_filter {
@@ -614,7 +614,7 @@ impl User {
                 forbid_stats.add_dest_denied();
                 return action;
             }
-            default_action = default_action.restrict(&action);
+            default_action = default_action.restrict(action);
         }
 
         if default_action.forbid_early() {
@@ -636,7 +636,7 @@ impl User {
                         forbid_stats.add_ua_blocked();
                         return Some(action);
                     }
-                    default_action = default_action.restrict(&action);
+                    default_action = default_action.restrict(action);
                 }
             }
             Some(default_action)

--- a/g3proxy/src/config/audit/auditor.rs
+++ b/g3proxy/src/config/audit/auditor.rs
@@ -85,12 +85,24 @@ impl AuditorConfig {
             tls_stream_dump: None,
             log_uri_max_chars: 1024,
             h1_interception: Default::default(),
-            h2_inspect_policy: ProtocolInspectPolicy::Intercept,
+            h2_inspect_policy: ProtocolInspectPolicy::builder_with_missing_action(
+                g3_dpi::ProtocolInspectAction::Intercept,
+            )
+            .build(),
             h2_interception: Default::default(),
-            websocket_inspect_policy: ProtocolInspectPolicy::Intercept,
-            smtp_inspect_policy: ProtocolInspectPolicy::Intercept,
+            websocket_inspect_policy: ProtocolInspectPolicy::builder_with_missing_action(
+                g3_dpi::ProtocolInspectAction::Intercept,
+            )
+            .build(),
+            smtp_inspect_policy: ProtocolInspectPolicy::builder_with_missing_action(
+                g3_dpi::ProtocolInspectAction::Intercept,
+            )
+            .build(),
             smtp_interception: Default::default(),
-            imap_inspect_policy: ProtocolInspectPolicy::Intercept,
+            imap_inspect_policy: ProtocolInspectPolicy::builder_with_missing_action(
+                g3_dpi::ProtocolInspectAction::Intercept,
+            )
+            .build(),
             imap_interception: Default::default(),
             icap_reqmod_service: None,
             icap_respmod_service: None,

--- a/g3proxy/src/inspect/http/v1/upgrade/mod.rs
+++ b/g3proxy/src/inspect/http/v1/upgrade/mod.rs
@@ -154,11 +154,8 @@ where
         CW: AsyncWrite + Unpin,
     {
         let policy_action = match self.req.host.as_ref() {
-            Some(upstream) => {
-                let (_, policy_action) = self.ctx.websocket_inspect_policy().check(upstream.host());
-                policy_action
-            }
-            None => self.ctx.websocket_inspect_policy().missing_action(),
+            Some(upstream) => self.ctx.websocket_inspect_action(upstream.host()),
+            None => self.ctx.websocket_inspect_missing_action(),
         };
         let block_websocket = policy_action == ProtocolInspectAction::Block;
 

--- a/g3proxy/src/inspect/http/v2/connect/extended.rs
+++ b/g3proxy/src/inspect/http/v2/connect/extended.rs
@@ -179,11 +179,8 @@ where
         };
 
         let policy_action = match self.upstream.as_ref() {
-            Some(upstream) => {
-                let (_, policy_action) = self.ctx.websocket_inspect_policy().check(upstream.host());
-                policy_action
-            }
-            None => self.ctx.websocket_inspect_policy().missing_action(),
+            Some(upstream) => self.ctx.websocket_inspect_action(upstream.host()),
+            None => self.ctx.websocket_inspect_missing_action(),
         };
         if policy_action == ProtocolInspectAction::Block {
             self.reply_forbidden(clt_send_rsp);

--- a/g3proxy/src/inspect/http/v2/mod.rs
+++ b/g3proxy/src/inspect/http/v2/mod.rs
@@ -110,8 +110,7 @@ where
     SC: ServerConfig + Send + Sync + 'static,
 {
     pub(crate) async fn intercept(mut self) -> ServerTaskResult<()> {
-        let (_, inspect_action) = self.ctx.h2_inspect_policy().check(self.upstream.host());
-        let r = match inspect_action {
+        let r = match self.ctx.h2_inspect_action(self.upstream.host()) {
             ProtocolInspectAction::Intercept => self
                 .do_intercept()
                 .await

--- a/g3proxy/src/inspect/imap/mod.rs
+++ b/g3proxy/src/inspect/imap/mod.rs
@@ -18,7 +18,7 @@ use anyhow::anyhow;
 use slog::slog_info;
 use tokio::io::AsyncWriteExt;
 
-use g3_dpi::ProtocolInspectPolicy;
+use g3_dpi::ProtocolInspectAction;
 use g3_imap_proto::response::ByeResponse;
 use g3_imap_proto::CommandPipeline;
 use g3_io_ext::{LineRecvVec, OnceBufReader};
@@ -130,12 +130,13 @@ where
     }
 
     pub(crate) async fn intercept(mut self) -> ServerTaskResult<Option<StreamInspection<SC>>> {
-        let r = match self.ctx.imap_inspect_policy() {
-            ProtocolInspectPolicy::Intercept => self.do_intercept().await,
+        let (_, inspect_action) = self.ctx.imap_inspect_policy().check(self.upstream.host());
+        let r = match inspect_action {
+            ProtocolInspectAction::Intercept => self.do_intercept().await,
             #[cfg(feature = "quic")]
-            ProtocolInspectPolicy::Detour => self.do_detour().await.map(|_| None),
-            ProtocolInspectPolicy::Bypass => self.do_bypass().await.map(|_| None),
-            ProtocolInspectPolicy::Block => self.do_block().await.map(|_| None),
+            ProtocolInspectAction::Detour => self.do_detour().await.map(|_| None),
+            ProtocolInspectAction::Bypass => self.do_bypass().await.map(|_| None),
+            ProtocolInspectAction::Block => self.do_block().await.map(|_| None),
         };
         match r {
             Ok(obj) => {

--- a/g3proxy/src/inspect/imap/mod.rs
+++ b/g3proxy/src/inspect/imap/mod.rs
@@ -130,8 +130,7 @@ where
     }
 
     pub(crate) async fn intercept(mut self) -> ServerTaskResult<Option<StreamInspection<SC>>> {
-        let (_, inspect_action) = self.ctx.imap_inspect_policy().check(self.upstream.host());
-        let r = match inspect_action {
+        let r = match self.ctx.imap_inspect_action(self.upstream.host()) {
             ProtocolInspectAction::Intercept => self.do_intercept().await,
             #[cfg(feature = "quic")]
             ProtocolInspectAction::Detour => self.do_detour().await.map(|_| None),

--- a/g3proxy/src/inspect/mod.rs
+++ b/g3proxy/src/inspect/mod.rs
@@ -263,7 +263,7 @@ impl<SC: ServerConfig> StreamInspectContext<SC> {
     }
 
     #[inline]
-    fn h2_inspect_policy(&self) -> ProtocolInspectPolicy {
+    fn h2_inspect_policy(&self) -> &ProtocolInspectPolicy {
         self.audit_handle.h2_inspect_policy()
     }
 
@@ -281,12 +281,12 @@ impl<SC: ServerConfig> StreamInspectContext<SC> {
     }
 
     #[inline]
-    fn websocket_inspect_policy(&self) -> ProtocolInspectPolicy {
+    fn websocket_inspect_policy(&self) -> &ProtocolInspectPolicy {
         self.audit_handle.websocket_inspect_policy()
     }
 
     #[inline]
-    fn smtp_inspect_policy(&self) -> ProtocolInspectPolicy {
+    fn smtp_inspect_policy(&self) -> &ProtocolInspectPolicy {
         self.audit_handle.smtp_inspect_policy()
     }
 
@@ -296,7 +296,7 @@ impl<SC: ServerConfig> StreamInspectContext<SC> {
     }
 
     #[inline]
-    fn imap_inspect_policy(&self) -> ProtocolInspectPolicy {
+    fn imap_inspect_policy(&self) -> &ProtocolInspectPolicy {
         self.audit_handle.imap_inspect_policy()
     }
 

--- a/g3proxy/src/inspect/mod.rs
+++ b/g3proxy/src/inspect/mod.rs
@@ -25,9 +25,9 @@ use uuid::Uuid;
 use g3_daemon::server::ServerQuitPolicy;
 use g3_dpi::{
     H1InterceptionConfig, H2InterceptionConfig, ImapInterceptionConfig, MaybeProtocol,
-    ProtocolInspectPolicy, ProtocolInspector, SmtpInterceptionConfig,
+    ProtocolInspectAction, ProtocolInspector, SmtpInterceptionConfig,
 };
-use g3_types::net::OpensslClientConfig;
+use g3_types::net::{Host, OpensslClientConfig};
 
 use crate::audit::AuditHandle;
 use crate::auth::{User, UserForbiddenStats, UserSite};
@@ -263,8 +263,17 @@ impl<SC: ServerConfig> StreamInspectContext<SC> {
     }
 
     #[inline]
-    fn h2_inspect_policy(&self) -> &ProtocolInspectPolicy {
-        self.audit_handle.h2_inspect_policy()
+    fn h2_inspect_action(&self, host: &Host) -> ProtocolInspectAction {
+        match self.audit_handle.h2_inspect_policy().check(host) {
+            (true, policy_action) => policy_action,
+            (false, missing_policy_action) => missing_policy_action,
+        }
+    }
+
+    #[inline]
+    #[allow(dead_code)]
+    fn h2_inspect_missing_action(&self) -> ProtocolInspectAction {
+        self.audit_handle.h2_inspect_policy().missing_action()
     }
 
     #[inline]
@@ -281,13 +290,32 @@ impl<SC: ServerConfig> StreamInspectContext<SC> {
     }
 
     #[inline]
-    fn websocket_inspect_policy(&self) -> &ProtocolInspectPolicy {
-        self.audit_handle.websocket_inspect_policy()
+    fn websocket_inspect_action(&self, host: &Host) -> ProtocolInspectAction {
+        match self.audit_handle.websocket_inspect_policy().check(host) {
+            (true, policy_action) => policy_action,
+            (false, missing_policy_action) => missing_policy_action,
+        }
     }
 
     #[inline]
-    fn smtp_inspect_policy(&self) -> &ProtocolInspectPolicy {
-        self.audit_handle.smtp_inspect_policy()
+    fn websocket_inspect_missing_action(&self) -> ProtocolInspectAction {
+        self.audit_handle
+            .websocket_inspect_policy()
+            .missing_action()
+    }
+
+    #[inline]
+    fn smtp_inspect_action(&self, host: &Host) -> ProtocolInspectAction {
+        match self.audit_handle.smtp_inspect_policy().check(host) {
+            (true, policy_action) => policy_action,
+            (false, missing_policy_action) => missing_policy_action,
+        }
+    }
+
+    #[inline]
+    #[allow(dead_code)]
+    fn smtp_inspect_missing_action(&self) -> ProtocolInspectAction {
+        self.audit_handle.smtp_inspect_policy().missing_action()
     }
 
     #[inline]
@@ -296,8 +324,17 @@ impl<SC: ServerConfig> StreamInspectContext<SC> {
     }
 
     #[inline]
-    fn imap_inspect_policy(&self) -> &ProtocolInspectPolicy {
-        self.audit_handle.imap_inspect_policy()
+    fn imap_inspect_action(&self, host: &Host) -> ProtocolInspectAction {
+        match self.audit_handle.imap_inspect_policy().check(host) {
+            (true, policy_action) => policy_action,
+            (false, missing_policy_action) => missing_policy_action,
+        }
+    }
+
+    #[inline]
+    #[allow(dead_code)]
+    fn imap_inspect_missing_action(&self) -> ProtocolInspectAction {
+        self.audit_handle.imap_inspect_policy().missing_action()
     }
 
     #[inline]

--- a/g3proxy/src/inspect/smtp/mod.rs
+++ b/g3proxy/src/inspect/smtp/mod.rs
@@ -121,8 +121,7 @@ where
     }
 
     pub(crate) async fn intercept(mut self) -> ServerTaskResult<Option<StreamInspection<SC>>> {
-        let (_, inspect_action) = self.ctx.smtp_inspect_policy().check(self.upstream.host());
-        let r = match inspect_action {
+        let r = match self.ctx.smtp_inspect_action(self.upstream.host()) {
             ProtocolInspectAction::Intercept => self.do_intercept().await,
             #[cfg(feature = "quic")]
             ProtocolInspectAction::Detour => self.do_detour().await.map(|_| None),

--- a/g3proxy/src/inspect/tls/mod.rs
+++ b/g3proxy/src/inspect/tls/mod.rs
@@ -167,14 +167,14 @@ impl<SC: ServerConfig> TlsInterceptObject<SC> {
 
     fn retain_alpn_protocol(&self, p: &[u8]) -> bool {
         if p == AlpnProtocol::Http2.identification_sequence() {
-            let (_, inspect_policy) = self.ctx.h2_inspect_policy().check(self.upstream.host());
-            return inspect_policy != ProtocolInspectAction::Block;
+            return ProtocolInspectAction::Block
+                != self.ctx.h2_inspect_action(self.upstream.host());
         } else if p == AlpnProtocol::Smtp.identification_sequence() {
-            let (_, inspect_policy) = self.ctx.smtp_inspect_policy().check(self.upstream.host());
-            return inspect_policy != ProtocolInspectAction::Block;
+            return ProtocolInspectAction::Block
+                != self.ctx.smtp_inspect_action(self.upstream.host());
         } else if p == AlpnProtocol::Imap.identification_sequence() {
-            let (_, inspect_policy) = self.ctx.imap_inspect_policy().check(self.upstream.host());
-            return inspect_policy != ProtocolInspectAction::Block;
+            return ProtocolInspectAction::Block
+                != self.ctx.imap_inspect_action(self.upstream.host());
         }
         true
     }

--- a/g3proxy/src/inspect/websocket/h1.rs
+++ b/g3proxy/src/inspect/websocket/h1.rs
@@ -90,11 +90,7 @@ impl<SC: ServerConfig> H1WebsocketInterceptObject<SC> {
     }
 
     pub(crate) async fn intercept(mut self) -> ServerTaskResult<()> {
-        let (_, inspect_action) = self
-            .ctx
-            .websocket_inspect_policy()
-            .check(self.upstream.host());
-        let r = match inspect_action {
+        let r = match self.ctx.websocket_inspect_action(self.upstream.host()) {
             ProtocolInspectAction::Intercept => self.do_intercept().await,
             #[cfg(feature = "quic")]
             ProtocolInspectAction::Detour => self.do_detour().await,

--- a/g3proxy/src/inspect/websocket/h2.rs
+++ b/g3proxy/src/inspect/websocket/h2.rs
@@ -74,11 +74,7 @@ impl<SC: ServerConfig> H2WebsocketInterceptObject<SC> {
         ups_r: RecvStream,
         ups_w: SendStream<Bytes>,
     ) {
-        let (_, inspect_action) = self
-            .ctx
-            .websocket_inspect_policy()
-            .check(self.upstream.host());
-        let r = match inspect_action {
+        let r = match self.ctx.websocket_inspect_action(self.upstream.host()) {
             ProtocolInspectAction::Intercept => self.do_intercept(clt_r, clt_w, ups_r, ups_w).await,
             #[cfg(feature = "quic")]
             ProtocolInspectAction::Detour => self.do_detour(clt_r, clt_w, ups_r, ups_w).await,

--- a/g3proxy/src/serve/http_proxy/task/common.rs
+++ b/g3proxy/src/serve/http_proxy/task/common.rs
@@ -21,7 +21,7 @@ use slog::Logger;
 
 use g3_daemon::server::ClientConnectionInfo;
 use g3_icap_client::reqmod::h1::HttpAdapterErrorResponse;
-use g3_types::acl::{AclAction, ActionContract};
+use g3_types::acl::AclAction;
 use g3_types::acl_set::AclDstHostRuleSet;
 use g3_types::net::{OpensslClientConfig, UpstreamAddr};
 
@@ -73,7 +73,7 @@ impl CommonTaskContext {
             if found && action.forbid_early() {
                 return action;
             };
-            default_action = default_action.restrict(&action);
+            default_action = default_action.restrict(action);
         }
 
         if let Some(filter) = &self.dst_host_filter {
@@ -81,7 +81,7 @@ impl CommonTaskContext {
             if found && action.forbid_early() {
                 return action;
             }
-            default_action = default_action.restrict(&action);
+            default_action = default_action.restrict(action);
         }
 
         default_action

--- a/g3proxy/src/serve/http_proxy/task/common.rs
+++ b/g3proxy/src/serve/http_proxy/task/common.rs
@@ -21,7 +21,7 @@ use slog::Logger;
 
 use g3_daemon::server::ClientConnectionInfo;
 use g3_icap_client::reqmod::h1::HttpAdapterErrorResponse;
-use g3_types::acl::AclAction;
+use g3_types::acl::{AclAction, ActionContract};
 use g3_types::acl_set::AclDstHostRuleSet;
 use g3_types::net::{OpensslClientConfig, UpstreamAddr};
 
@@ -73,7 +73,7 @@ impl CommonTaskContext {
             if found && action.forbid_early() {
                 return action;
             };
-            default_action = default_action.restrict(action);
+            default_action = default_action.restrict(&action);
         }
 
         if let Some(filter) = &self.dst_host_filter {
@@ -81,7 +81,7 @@ impl CommonTaskContext {
             if found && action.forbid_early() {
                 return action;
             }
-            default_action = default_action.restrict(action);
+            default_action = default_action.restrict(&action);
         }
 
         default_action

--- a/g3proxy/src/serve/socks_proxy/task/common.rs
+++ b/g3proxy/src/serve/socks_proxy/task/common.rs
@@ -21,7 +21,7 @@ use slog::Logger;
 use tokio::net::UdpSocket;
 
 use g3_daemon::server::ClientConnectionInfo;
-use g3_types::acl::{AclAction, AclNetworkRule, ActionContract};
+use g3_types::acl::{AclAction, AclNetworkRule};
 use g3_types::acl_set::AclDstHostRuleSet;
 use g3_types::net::UpstreamAddr;
 
@@ -70,7 +70,7 @@ impl CommonTaskContext {
             if found && action.forbid_early() {
                 return action;
             };
-            default_action = default_action.restrict(&action);
+            default_action = default_action.restrict(action);
         }
 
         if let Some(filter) = &self.dst_host_filter {
@@ -78,7 +78,7 @@ impl CommonTaskContext {
             if found && action.forbid_early() {
                 return action;
             }
-            default_action = default_action.restrict(&action);
+            default_action = default_action.restrict(action);
         }
 
         default_action

--- a/g3proxy/src/serve/socks_proxy/task/common.rs
+++ b/g3proxy/src/serve/socks_proxy/task/common.rs
@@ -21,7 +21,7 @@ use slog::Logger;
 use tokio::net::UdpSocket;
 
 use g3_daemon::server::ClientConnectionInfo;
-use g3_types::acl::{AclAction, AclNetworkRule};
+use g3_types::acl::{AclAction, AclNetworkRule, ActionContract};
 use g3_types::acl_set::AclDstHostRuleSet;
 use g3_types::net::UpstreamAddr;
 
@@ -70,7 +70,7 @@ impl CommonTaskContext {
             if found && action.forbid_early() {
                 return action;
             };
-            default_action = default_action.restrict(action);
+            default_action = default_action.restrict(&action);
         }
 
         if let Some(filter) = &self.dst_host_filter {
@@ -78,7 +78,7 @@ impl CommonTaskContext {
             if found && action.forbid_early() {
                 return action;
             }
-            default_action = default_action.restrict(action);
+            default_action = default_action.restrict(&action);
         }
 
         default_action

--- a/lib/g3-dpi/src/lib.rs
+++ b/lib/g3-dpi/src/lib.rs
@@ -25,8 +25,9 @@ pub use protocol::{
 
 mod config;
 pub use config::{
-    H1InterceptionConfig, H2InterceptionConfig, ImapInterceptionConfig, ProtocolInspectPolicy,
-    ProtocolInspectionConfig, ProtocolInspectionSizeLimit, SmtpInterceptionConfig,
+    H1InterceptionConfig, H2InterceptionConfig, ImapInterceptionConfig, ProtocolInspectAction,
+    ProtocolInspectPolicy, ProtocolInspectionConfig, ProtocolInspectionSizeLimit,
+    SmtpInterceptionConfig,
 };
 
 pub mod parser;

--- a/lib/g3-json/src/value/acl_set/dst_host.rs
+++ b/lib/g3-json/src/value/acl_set/dst_host.rs
@@ -21,12 +21,7 @@ use g3_types::acl_set::AclDstHostRuleSetBuilder;
 
 pub fn as_dst_host_rule_set_builder(value: &Value) -> anyhow::Result<AclDstHostRuleSetBuilder> {
     if let Value::Object(map) = value {
-        let mut builder = AclDstHostRuleSetBuilder {
-            exact: None,
-            child: None,
-            regex: None,
-            subnet: None,
-        };
+        let mut builder = AclDstHostRuleSetBuilder::default();
         for (k, v) in map {
             match crate::key::normalize(k).as_str() {
                 "exact_match" | "exact" => {

--- a/lib/g3-types/src/acl/a_hash.rs
+++ b/lib/g3-types/src/acl/a_hash.rs
@@ -68,9 +68,9 @@ where
         Q: Hash + Eq + ?Sized,
     {
         if let Some(action) = self.inner.get(node) {
-            (true, action.clone())
+            (true, *action)
         } else {
-            (false, self.missed_action.clone())
+            (false, self.missed_action)
         }
     }
 }

--- a/lib/g3-types/src/acl/child_domain.rs
+++ b/lib/g3-types/src/acl/child_domain.rs
@@ -14,44 +14,45 @@
  * limitations under the License.
  */
 
-use super::{AclAction, AclRadixTrieRule, AclRadixTrieRuleBuilder};
+use super::{AclAction, AclRadixTrieRule, AclRadixTrieRuleBuilder, ActionContract};
 use crate::resolve::reverse_idna_domain;
 
 #[derive(Clone, Debug, Eq, PartialEq)]
-pub struct AclChildDomainRuleBuilder(AclRadixTrieRuleBuilder<String>);
+pub struct AclChildDomainRuleBuilder<Action = AclAction>(AclRadixTrieRuleBuilder<String, Action>);
 
-impl AclChildDomainRuleBuilder {
+impl<Action: ActionContract> AclChildDomainRuleBuilder<Action> {
     #[inline]
-    pub fn new(missed_action: AclAction) -> Self {
+    pub fn new(missed_action: Action) -> Self {
         AclChildDomainRuleBuilder(AclRadixTrieRuleBuilder::new(missed_action))
     }
 
     #[inline]
-    pub fn add_node(&mut self, domain: &str, action: AclAction) {
+    pub fn add_node(&mut self, domain: &str, action: Action) {
         self.0.add_node(reverse_idna_domain(domain), action);
     }
 
     #[inline]
-    pub fn set_missed_action(&mut self, action: AclAction) {
+    pub fn set_missed_action(&mut self, action: Action) {
         self.0.set_missed_action(action);
     }
 
     #[inline]
-    pub fn missed_action(&self) -> AclAction {
+    pub fn missed_action(&self) -> Action {
         self.0.missed_action()
     }
 
     #[inline]
-    pub fn build(&self) -> AclChildDomainRule {
+    pub fn build(&self) -> AclChildDomainRule<Action> {
         AclChildDomainRule(self.0.build())
     }
 }
 
-pub struct AclChildDomainRule(AclRadixTrieRule<String>);
+#[derive(Clone)]
+pub struct AclChildDomainRule<Action = AclAction>(AclRadixTrieRule<String, Action>);
 
-impl AclChildDomainRule {
+impl<Action: ActionContract> AclChildDomainRule<Action> {
     #[inline]
-    pub fn check(&self, host: &str) -> (bool, AclAction) {
+    pub fn check(&self, host: &str) -> (bool, Action) {
         let s = reverse_idna_domain(host);
         self.0.check(&s)
     }

--- a/lib/g3-types/src/acl/exact_host.rs
+++ b/lib/g3-types/src/acl/exact_host.rs
@@ -31,8 +31,8 @@ impl<Action: ActionContract> AclExactHostRule<Action> {
     #[inline]
     pub fn new(missed_action: Action) -> Self {
         AclExactHostRule {
-            missed_action: missed_action.clone(),
-            domain: AclAHashRule::new(missed_action.clone()),
+            missed_action,
+            domain: AclAHashRule::new(missed_action),
             ip: AclAHashRule::new(missed_action),
         }
     }
@@ -56,14 +56,14 @@ impl<Action: ActionContract> AclExactHostRule<Action> {
 
     #[inline]
     pub fn set_missed_action(&mut self, action: Action) {
-        self.missed_action = action.clone();
-        self.domain.set_missed_action(action.clone());
+        self.missed_action = action;
+        self.domain.set_missed_action(action);
         self.ip.set_missed_action(action);
     }
 
     #[inline]
     pub fn missed_action(&self) -> Action {
-        self.missed_action.clone()
+        self.missed_action
     }
 
     #[inline]

--- a/lib/g3-types/src/acl/exact_port.rs
+++ b/lib/g3-types/src/acl/exact_port.rs
@@ -30,13 +30,13 @@ impl<Action: ActionContract> AclExactPortRule<Action> {
 
     pub fn add_port_range(&mut self, port_range: RangeInclusive<u16>, action: Action) {
         for port in port_range {
-            self.0.add_node(port, action.clone());
+            self.0.add_node(port, action);
         }
     }
 
     pub fn add_ports(&mut self, ports: Ports, action: Action) {
         for port in ports {
-            self.0.add_node(port, action.clone());
+            self.0.add_node(port, action);
         }
     }
 

--- a/lib/g3-types/src/acl/exact_port.rs
+++ b/lib/g3-types/src/acl/exact_port.rs
@@ -16,42 +16,42 @@
 
 use std::ops::RangeInclusive;
 
-use super::{AclAction, AclFxHashRule};
+use super::{AclAction, AclFxHashRule, ActionContract};
 use crate::net::Ports;
 
 #[derive(Clone, Debug, Eq, PartialEq)]
-pub struct AclExactPortRule(AclFxHashRule<u16>);
+pub struct AclExactPortRule<Action = AclAction>(AclFxHashRule<u16, Action>);
 
-impl AclExactPortRule {
+impl<Action: ActionContract> AclExactPortRule<Action> {
     #[inline]
-    pub fn new(missed_action: AclAction) -> Self {
+    pub fn new(missed_action: Action) -> Self {
         AclExactPortRule(AclFxHashRule::new(missed_action))
     }
 
-    pub fn add_port_range(&mut self, port_range: RangeInclusive<u16>, action: AclAction) {
+    pub fn add_port_range(&mut self, port_range: RangeInclusive<u16>, action: Action) {
         for port in port_range {
-            self.0.add_node(port, action);
+            self.0.add_node(port, action.clone());
         }
     }
 
-    pub fn add_ports(&mut self, ports: Ports, action: AclAction) {
+    pub fn add_ports(&mut self, ports: Ports, action: Action) {
         for port in ports {
-            self.0.add_node(port, action);
+            self.0.add_node(port, action.clone());
         }
     }
 
     #[inline]
-    pub fn add_port(&mut self, port: u16, action: AclAction) {
+    pub fn add_port(&mut self, port: u16, action: Action) {
         self.0.add_node(port, action);
     }
 
     #[inline]
-    pub fn set_missed_action(&mut self, action: AclAction) {
+    pub fn set_missed_action(&mut self, action: Action) {
         self.0.set_missed_action(action);
     }
 
     #[inline]
-    pub fn check_port(&self, port: &u16) -> (bool, AclAction) {
+    pub fn check_port(&self, port: &u16) -> (bool, Action) {
         self.0.check(port)
     }
 }

--- a/lib/g3-types/src/acl/fx_hash.rs
+++ b/lib/g3-types/src/acl/fx_hash.rs
@@ -68,9 +68,9 @@ where
         Q: Hash + Eq + ?Sized,
     {
         if let Some(action) = self.inner.get(node) {
-            (true, action.clone())
+            (true, *action)
         } else {
-            (false, self.missed_action.clone())
+            (false, self.missed_action)
         }
     }
 }

--- a/lib/g3-types/src/acl/fx_hash.rs
+++ b/lib/g3-types/src/acl/fx_hash.rs
@@ -19,31 +19,33 @@ use std::hash::Hash;
 
 use rustc_hash::FxHashMap;
 
-use super::AclAction;
+use super::{AclAction, ActionContract};
 
 #[derive(Clone, Debug, Eq, PartialEq)]
-pub struct AclFxHashRule<K>
+pub struct AclFxHashRule<K, Action = AclAction>
 where
     K: Hash + Eq,
 {
-    inner: FxHashMap<K, AclAction>,
-    missed_action: AclAction,
+    inner: FxHashMap<K, Action>,
+    missed_action: Action,
 }
 
-impl<K> Default for AclFxHashRule<K>
+impl<K, Action> Default for AclFxHashRule<K, Action>
 where
     K: Hash + Eq,
+    Action: ActionContract,
 {
     fn default() -> Self {
-        Self::new(AclAction::Forbid)
+        Self::new(Action::default_forbid())
     }
 }
 
-impl<K> AclFxHashRule<K>
+impl<K, Action> AclFxHashRule<K, Action>
 where
     K: Hash + Eq,
+    Action: ActionContract,
 {
-    pub fn new(missed_action: AclAction) -> Self {
+    pub fn new(missed_action: Action) -> Self {
         AclFxHashRule {
             inner: FxHashMap::default(),
             missed_action,
@@ -51,24 +53,24 @@ where
     }
 
     #[inline]
-    pub fn add_node(&mut self, node: K, action: AclAction) {
+    pub fn add_node(&mut self, node: K, action: Action) {
         self.inner.insert(node, action);
     }
 
     #[inline]
-    pub fn set_missed_action(&mut self, action: AclAction) {
+    pub fn set_missed_action(&mut self, action: Action) {
         self.missed_action = action;
     }
 
-    pub fn check<Q>(&self, node: &Q) -> (bool, AclAction)
+    pub fn check<Q>(&self, node: &Q) -> (bool, Action)
     where
         K: Borrow<Q>,
         Q: Hash + Eq + ?Sized,
     {
         if let Some(action) = self.inner.get(node) {
-            (true, *action)
+            (true, action.clone())
         } else {
-            (false, self.missed_action)
+            (false, self.missed_action.clone())
         }
     }
 }

--- a/lib/g3-types/src/acl/network.rs
+++ b/lib/g3-types/src/acl/network.rs
@@ -87,7 +87,7 @@ impl<Action: ActionContract> AclNetworkRuleBuilder<Action> {
 
     #[inline]
     pub fn missed_action(&self) -> Action {
-        self.missed_action.clone()
+        self.missed_action
     }
 
     #[inline]
@@ -98,11 +98,11 @@ impl<Action: ActionContract> AclNetworkRuleBuilder<Action> {
     pub fn build(&self) -> AclNetworkRule<Action> {
         let mut inner = IpNetworkTable::new();
         for (net, action) in &self.inner {
-            inner.insert(*net, action.clone());
+            inner.insert(*net, *action);
         }
         AclNetworkRule {
             inner,
-            default_action: self.missed_action.clone(),
+            default_action: self.missed_action,
         }
     }
 }
@@ -119,11 +119,11 @@ impl<Action: ActionContract> Clone for AclNetworkRule<Action> {
                 let (ipv4_size, ipv6_size) = self.inner.len();
                 let mut table = IpNetworkTable::with_capacity(ipv4_size, ipv6_size);
                 for (k, v) in self.inner.iter() {
-                    table.insert(k, v.clone());
+                    table.insert(k, *v);
                 }
                 table
             },
-            default_action: self.default_action.clone(),
+            default_action: self.default_action,
         }
     }
 }
@@ -131,9 +131,9 @@ impl<Action: ActionContract> Clone for AclNetworkRule<Action> {
 impl<Action: ActionContract> AclNetworkRule<Action> {
     pub fn check(&self, ip: IpAddr) -> (bool, Action) {
         if let Some((_, action)) = self.inner.longest_match(ip) {
-            (true, action.clone())
+            (true, *action)
         } else {
-            (false, self.default_action.clone())
+            (false, self.default_action)
         }
     }
 }

--- a/lib/g3-types/src/acl/proxy_request.rs
+++ b/lib/g3-types/src/acl/proxy_request.rs
@@ -27,7 +27,7 @@ impl<Action: ActionContract> AclProxyRequestRule<Action> {
     #[inline]
     pub fn new(missed_action: Action) -> Self {
         AclProxyRequestRule {
-            missed_action: missed_action.clone(),
+            missed_action,
             request: AclAHashRule::new(missed_action),
         }
     }
@@ -39,13 +39,13 @@ impl<Action: ActionContract> AclProxyRequestRule<Action> {
 
     #[inline]
     pub fn set_missed_action(&mut self, action: Action) {
-        self.missed_action = action.clone();
+        self.missed_action = action;
         self.request.set_missed_action(action);
     }
 
     #[inline]
     pub fn missed_action(&self) -> Action {
-        self.missed_action.clone()
+        self.missed_action
     }
 
     #[inline]

--- a/lib/g3-types/src/acl/proxy_request.rs
+++ b/lib/g3-types/src/acl/proxy_request.rs
@@ -14,42 +14,42 @@
  * limitations under the License.
  */
 
-use super::{AclAHashRule, AclAction};
+use super::{AclAHashRule, AclAction, ActionContract};
 use crate::net::ProxyRequestType;
 
 #[derive(Clone)]
-pub struct AclProxyRequestRule {
-    missed_action: AclAction,
-    request: AclAHashRule<ProxyRequestType>,
+pub struct AclProxyRequestRule<Action = AclAction> {
+    missed_action: Action,
+    request: AclAHashRule<ProxyRequestType, Action>,
 }
 
-impl AclProxyRequestRule {
+impl<Action: ActionContract> AclProxyRequestRule<Action> {
     #[inline]
-    pub fn new(missed_action: AclAction) -> Self {
+    pub fn new(missed_action: Action) -> Self {
         AclProxyRequestRule {
-            missed_action,
+            missed_action: missed_action.clone(),
             request: AclAHashRule::new(missed_action),
         }
     }
 
     #[inline]
-    pub fn add_request_type(&mut self, request: ProxyRequestType, action: AclAction) {
+    pub fn add_request_type(&mut self, request: ProxyRequestType, action: Action) {
         self.request.add_node(request, action);
     }
 
     #[inline]
-    pub fn set_missed_action(&mut self, action: AclAction) {
-        self.missed_action = action;
+    pub fn set_missed_action(&mut self, action: Action) {
+        self.missed_action = action.clone();
         self.request.set_missed_action(action);
     }
 
     #[inline]
-    pub fn missed_action(&self) -> AclAction {
-        self.missed_action
+    pub fn missed_action(&self) -> Action {
+        self.missed_action.clone()
     }
 
     #[inline]
-    pub fn check_request(&self, request: &ProxyRequestType) -> (bool, AclAction) {
+    pub fn check_request(&self, request: &ProxyRequestType) -> (bool, Action) {
         self.request.check(request)
     }
 }

--- a/lib/g3-types/src/acl/radix_trie.rs
+++ b/lib/g3-types/src/acl/radix_trie.rs
@@ -55,19 +55,19 @@ where
 
     #[inline]
     pub fn missed_action(&self) -> Action {
-        self.missed_action.clone()
+        self.missed_action
     }
 
     pub fn build(&self) -> AclRadixTrieRule<K, Action> {
         let mut trie = Trie::new();
 
         for (k, v) in &self.inner {
-            trie.insert(k.clone(), v.clone());
+            trie.insert(k.clone(), *v);
         }
 
         AclRadixTrieRule {
             inner: trie,
-            missed_action: self.missed_action.clone(),
+            missed_action: self.missed_action,
         }
     }
 }
@@ -85,9 +85,9 @@ impl<K: TrieKey, Action: ActionContract> AclRadixTrieRule<K, Action> {
         Q: TrieKey,
     {
         if let Some(action) = self.inner.get_ancestor_value(key) {
-            (true, action.clone())
+            (true, *action)
         } else {
-            (false, self.missed_action.clone())
+            (false, self.missed_action)
         }
     }
 }

--- a/lib/g3-types/src/acl/regex_set.rs
+++ b/lib/g3-types/src/acl/regex_set.rs
@@ -51,14 +51,14 @@ impl<Action: ActionContract> AclRegexSetRuleBuilder<Action> {
 
     #[inline]
     pub fn missed_action(&self) -> Action {
-        self.missed_action.clone()
+        self.missed_action
     }
 
     pub fn build(&self) -> AclRegexSetRule<Action> {
         let mut set_map: FxHashMap<Action, Vec<_>> = FxHashMap::default();
 
         for (r, action) in &self.inner {
-            set_map.entry(action.clone()).or_default().push(r.as_str());
+            set_map.entry(*action).or_default().push(r.as_str());
         }
 
         AclRegexSetRule {
@@ -66,7 +66,7 @@ impl<Action: ActionContract> AclRegexSetRuleBuilder<Action> {
                 .into_iter()
                 .map(|(k, v)| (k, RegexSet::new(v).unwrap()))
                 .collect(),
-            missed_action: self.missed_action.clone(),
+            missed_action: self.missed_action,
         }
     }
 }
@@ -81,10 +81,10 @@ impl<Action: ActionContract> AclRegexSetRule<Action> {
     pub fn check(&self, text: &str) -> (bool, Action) {
         for (action, set) in &self.set_map {
             if set.is_match(text) {
-                return (true, action.clone());
+                return (true, *action);
             }
         }
-        (false, self.missed_action.clone())
+        (false, self.missed_action)
     }
 }
 

--- a/lib/g3-types/src/acl/regex_set.rs
+++ b/lib/g3-types/src/acl/regex_set.rs
@@ -14,115 +14,77 @@
  * limitations under the License.
  */
 
-use std::collections::HashMap;
-
 use regex::{Regex, RegexSet};
+use rustc_hash::FxHashMap;
 
-use super::AclAction;
+use super::{AclAction, ActionContract};
 
 #[derive(Clone, Debug, Eq, PartialEq)]
-pub struct AclRegexSetRuleBuilder {
-    inner: HashMap<String, AclAction>,
-    missed_action: AclAction,
+pub struct AclRegexSetRuleBuilder<Action = AclAction> {
+    inner: FxHashMap<String, Action>,
+    missed_action: Action,
 }
 
-impl Default for AclRegexSetRuleBuilder {
+impl<Action: ActionContract> Default for AclRegexSetRuleBuilder<Action> {
     fn default() -> Self {
-        Self::new(AclAction::Forbid)
+        Self::new(Action::default_forbid())
     }
 }
 
-impl AclRegexSetRuleBuilder {
-    pub fn new(missed_action: AclAction) -> Self {
+impl<Action: ActionContract> AclRegexSetRuleBuilder<Action> {
+    pub fn new(missed_action: Action) -> Self {
         AclRegexSetRuleBuilder {
-            inner: HashMap::new(),
+            inner: FxHashMap::default(),
             missed_action,
         }
     }
 
     #[inline]
-    pub fn add_regex(&mut self, regex: &Regex, action: AclAction) {
+    pub fn add_regex(&mut self, regex: &Regex, action: Action) {
         self.inner.insert(regex.as_str().to_string(), action);
     }
 
     #[inline]
-    pub fn set_missed_action(&mut self, action: AclAction) {
+    pub fn set_missed_action(&mut self, action: Action) {
         self.missed_action = action;
     }
 
     #[inline]
-    pub fn missed_action(&self) -> AclAction {
-        self.missed_action
+    pub fn missed_action(&self) -> Action {
+        self.missed_action.clone()
     }
 
-    pub fn build(&self) -> AclRegexSetRule {
-        let mut forbid_log_v = Vec::new();
-        let mut forbid_v = Vec::new();
-        let mut permit_log_v = Vec::new();
-        let mut permit_v = Vec::new();
+    pub fn build(&self) -> AclRegexSetRule<Action> {
+        let mut set_map: FxHashMap<Action, Vec<_>> = FxHashMap::default();
 
         for (r, action) in &self.inner {
-            match action {
-                AclAction::ForbidAndLog => forbid_log_v.push(r.as_str()),
-                AclAction::Forbid => forbid_v.push(r.as_str()),
-                AclAction::PermitAndLog => permit_log_v.push(r.as_str()),
-                AclAction::Permit => permit_v.push(r.as_str()),
-            }
-        }
-
-        fn build_rs_from_vec(v: &[&str]) -> Option<RegexSet> {
-            if v.is_empty() {
-                None
-            } else {
-                Some(RegexSet::new(v).unwrap())
-            }
+            set_map.entry(action.clone()).or_default().push(r.as_str());
         }
 
         AclRegexSetRule {
-            forbid_log: build_rs_from_vec(&forbid_log_v),
-            forbid: build_rs_from_vec(&forbid_v),
-            permit_log: build_rs_from_vec(&permit_log_v),
-            permit: build_rs_from_vec(&permit_v),
-            missed_action: self.missed_action,
+            set_map: set_map
+                .into_iter()
+                .map(|(k, v)| (k, RegexSet::new(v).unwrap()))
+                .collect(),
+            missed_action: self.missed_action.clone(),
         }
     }
 }
 
-pub struct AclRegexSetRule {
-    forbid_log: Option<RegexSet>,
-    forbid: Option<RegexSet>,
-    permit_log: Option<RegexSet>,
-    permit: Option<RegexSet>,
-    missed_action: AclAction,
+#[derive(Clone)]
+pub struct AclRegexSetRule<Action = AclAction> {
+    set_map: FxHashMap<Action, RegexSet>,
+    missed_action: Action,
 }
 
-impl AclRegexSetRule {
-    pub fn check(&self, text: &str) -> (bool, AclAction) {
-        if let Some(rs) = &self.forbid_log {
-            if rs.is_match(text) {
-                return (true, AclAction::ForbidAndLog);
+impl<Action: ActionContract> AclRegexSetRule<Action> {
+    pub fn check(&self, text: &str) -> (bool, Action) {
+        for (action, set) in &self.set_map {
+            if set.is_match(text) {
+                return (true, action.clone());
             }
         }
-
-        if let Some(rs) = &self.forbid {
-            if rs.is_match(text) {
-                return (true, AclAction::Forbid);
-            }
-        }
-
-        if let Some(rs) = &self.permit_log {
-            if rs.is_match(text) {
-                return (true, AclAction::PermitAndLog);
-            }
-        }
-
-        if let Some(rs) = &self.permit {
-            if rs.is_match(text) {
-                return (true, AclAction::Permit);
-            }
-        }
-
-        (false, self.missed_action)
+        (false, self.missed_action.clone())
     }
 }
 

--- a/lib/g3-types/src/acl/user_agent.rs
+++ b/lib/g3-types/src/acl/user_agent.rs
@@ -45,7 +45,7 @@ impl<Action: ActionContract> AclUserAgentRule<Action> {
 
     #[inline]
     pub fn missed_action(&self) -> Action {
-        self.missed_action.clone()
+        self.missed_action
     }
 
     #[inline]
@@ -81,14 +81,14 @@ impl<Action: ActionContract> AclUserAgentRule<Action> {
                         continue;
                     }
 
-                    return (true, action.clone());
+                    return (true, *action);
                 } else {
                     break;
                 }
             }
         }
 
-        (false, self.missed_action.clone())
+        (false, self.missed_action)
     }
 }
 

--- a/lib/g3-yaml/src/value/acl/child_domain.rs
+++ b/lib/g3-yaml/src/value/acl/child_domain.rs
@@ -17,22 +17,22 @@
 use anyhow::anyhow;
 use yaml_rust::Yaml;
 
-use g3_types::acl::{AclAction, AclChildDomainRuleBuilder};
+use g3_types::acl::{AclChildDomainRuleBuilder, ActionContract};
 
 use super::AclRuleYamlParser;
 
-impl AclRuleYamlParser for AclChildDomainRuleBuilder {
+impl<Action: ActionContract> AclRuleYamlParser<Action> for AclChildDomainRuleBuilder<Action> {
     #[inline]
-    fn get_default_found_action(&self) -> AclAction {
-        AclAction::Permit
+    fn get_default_found_action(&self) -> Action {
+        Action::default_permit()
     }
 
     #[inline]
-    fn set_missed_action(&mut self, _action: AclAction) {
-        self.set_missed_action(_action);
+    fn set_missed_action(&mut self, action: Action) {
+        self.set_missed_action(action);
     }
 
-    fn add_rule_for_action(&mut self, action: AclAction, value: &Yaml) -> anyhow::Result<()> {
+    fn add_rule_for_action(&mut self, action: Action, value: &Yaml) -> anyhow::Result<()> {
         match value {
             Yaml::String(_) => {
                 let host = crate::value::as_domain(value)?;
@@ -44,10 +44,10 @@ impl AclRuleYamlParser for AclChildDomainRuleBuilder {
     }
 }
 
-pub(crate) fn as_child_domain_rule_builder(
+pub(crate) fn as_child_domain_rule_builder<Action: ActionContract>(
     value: &Yaml,
-) -> anyhow::Result<AclChildDomainRuleBuilder> {
-    let mut builder = AclChildDomainRuleBuilder::new(AclAction::Forbid);
+) -> anyhow::Result<AclChildDomainRuleBuilder<Action>> {
+    let mut builder = AclChildDomainRuleBuilder::new(Action::default_forbid());
     builder.parse(value)?;
     Ok(builder)
 }

--- a/lib/g3-yaml/src/value/acl/exact_host.rs
+++ b/lib/g3-yaml/src/value/acl/exact_host.rs
@@ -16,30 +16,32 @@
 
 use yaml_rust::Yaml;
 
-use g3_types::acl::{AclAction, AclExactHostRule};
+use g3_types::acl::{AclExactHostRule, ActionContract};
 
 use super::AclRuleYamlParser;
 
-impl AclRuleYamlParser for AclExactHostRule {
+impl<Action: ActionContract> AclRuleYamlParser<Action> for AclExactHostRule<Action> {
     #[inline]
-    fn get_default_found_action(&self) -> AclAction {
-        AclAction::Permit
+    fn get_default_found_action(&self) -> Action {
+        Action::default_permit()
     }
 
     #[inline]
-    fn set_missed_action(&mut self, _action: AclAction) {
-        self.set_missed_action(_action);
+    fn set_missed_action(&mut self, action: Action) {
+        self.set_missed_action(action);
     }
 
-    fn add_rule_for_action(&mut self, action: AclAction, value: &Yaml) -> anyhow::Result<()> {
+    fn add_rule_for_action(&mut self, action: Action, value: &Yaml) -> anyhow::Result<()> {
         let host = crate::value::as_host(value)?;
         self.add_host(host, action);
         Ok(())
     }
 }
 
-pub(crate) fn as_exact_host_rule(value: &Yaml) -> anyhow::Result<AclExactHostRule> {
-    let mut builder = AclExactHostRule::new(AclAction::Forbid);
+pub(crate) fn as_exact_host_rule<Action: ActionContract>(
+    value: &Yaml,
+) -> anyhow::Result<AclExactHostRule<Action>> {
+    let mut builder = AclExactHostRule::new(Action::default_forbid());
     builder.parse(value)?;
     Ok(builder)
 }

--- a/lib/g3-yaml/src/value/acl/exact_port.rs
+++ b/lib/g3-yaml/src/value/acl/exact_port.rs
@@ -16,30 +16,32 @@
 
 use yaml_rust::Yaml;
 
-use g3_types::acl::{AclAction, AclExactPortRule};
+use g3_types::acl::{AclExactPortRule, ActionContract};
 
 use super::AclRuleYamlParser;
 
-impl AclRuleYamlParser for AclExactPortRule {
+impl<Action: ActionContract> AclRuleYamlParser<Action> for AclExactPortRule<Action> {
     #[inline]
-    fn get_default_found_action(&self) -> AclAction {
-        AclAction::Permit
+    fn get_default_found_action(&self) -> Action {
+        Action::default_permit()
     }
 
     #[inline]
-    fn set_missed_action(&mut self, _action: AclAction) {
-        self.set_missed_action(_action);
+    fn set_missed_action(&mut self, action: Action) {
+        self.set_missed_action(action);
     }
 
-    fn add_rule_for_action(&mut self, action: AclAction, value: &Yaml) -> anyhow::Result<()> {
+    fn add_rule_for_action(&mut self, action: Action, value: &Yaml) -> anyhow::Result<()> {
         let ports = crate::value::as_ports(value)?;
         self.add_ports(ports, action);
         Ok(())
     }
 }
 
-pub fn as_exact_port_rule(value: &Yaml) -> anyhow::Result<AclExactPortRule> {
-    let mut builder = AclExactPortRule::new(AclAction::Forbid);
+pub fn as_exact_port_rule<Action: ActionContract>(
+    value: &Yaml,
+) -> anyhow::Result<AclExactPortRule<Action>> {
+    let mut builder = AclExactPortRule::new(Action::default_forbid());
     builder.parse(value)?;
     Ok(builder)
 }

--- a/lib/g3-yaml/src/value/acl/mod.rs
+++ b/lib/g3-yaml/src/value/acl/mod.rs
@@ -65,7 +65,7 @@ trait AclRuleYamlParser<Action: ActionContract> {
                             .map_err(|_| anyhow!("the key {k} is not a valid Action"))?;
                         if let Yaml::Array(seq) = v {
                             for (i, v) in seq.iter().enumerate() {
-                                self.add_rule_for_action(action.clone(), v)
+                                self.add_rule_for_action(action, v)
                                     .context(format!("invalid value for {k}#{i}"))?;
                             }
                             Ok(())

--- a/lib/g3-yaml/src/value/acl/network.rs
+++ b/lib/g3-yaml/src/value/acl/network.rs
@@ -16,42 +16,48 @@
 
 use yaml_rust::Yaml;
 
-use g3_types::acl::{AclAction, AclNetworkRuleBuilder};
+use g3_types::acl::{AclNetworkRuleBuilder, ActionContract};
 
 use super::AclRuleYamlParser;
 
-impl AclRuleYamlParser for AclNetworkRuleBuilder {
+impl<Action: ActionContract> AclRuleYamlParser<Action> for AclNetworkRuleBuilder<Action> {
     #[inline]
-    fn get_default_found_action(&self) -> AclAction {
-        AclAction::Permit
+    fn get_default_found_action(&self) -> Action {
+        Action::default_permit()
     }
 
     #[inline]
-    fn set_missed_action(&mut self, _action: AclAction) {
-        self.set_missed_action(_action);
+    fn set_missed_action(&mut self, action: Action) {
+        self.set_missed_action(action);
     }
 
-    fn add_rule_for_action(&mut self, action: AclAction, value: &Yaml) -> anyhow::Result<()> {
+    fn add_rule_for_action(&mut self, action: Action, value: &Yaml) -> anyhow::Result<()> {
         let net = crate::value::as_ip_network(value)?;
         self.add_network(net, action);
         Ok(())
     }
 }
 
-pub(crate) fn as_dst_subnet_rule_builder(value: &Yaml) -> anyhow::Result<AclNetworkRuleBuilder> {
-    let mut builder = AclNetworkRuleBuilder::new_egress(AclAction::Forbid);
+pub(crate) fn as_dst_subnet_rule_builder<Action: ActionContract>(
+    value: &Yaml,
+) -> anyhow::Result<AclNetworkRuleBuilder<Action>> {
+    let mut builder = AclNetworkRuleBuilder::new_egress(Action::default_forbid());
     builder.parse(value)?;
     Ok(builder)
 }
 
-pub fn as_egress_network_rule_builder(value: &Yaml) -> anyhow::Result<AclNetworkRuleBuilder> {
-    let mut builder = AclNetworkRuleBuilder::new_egress(AclAction::Forbid);
+pub fn as_egress_network_rule_builder<Action: ActionContract>(
+    value: &Yaml,
+) -> anyhow::Result<AclNetworkRuleBuilder<Action>> {
+    let mut builder = AclNetworkRuleBuilder::new_egress(Action::default_forbid());
     builder.parse(value)?;
     Ok(builder)
 }
 
-pub fn as_ingress_network_rule_builder(value: &Yaml) -> anyhow::Result<AclNetworkRuleBuilder> {
-    let mut builder = AclNetworkRuleBuilder::new_ingress(AclAction::Forbid);
+pub fn as_ingress_network_rule_builder<Action: ActionContract>(
+    value: &Yaml,
+) -> anyhow::Result<AclNetworkRuleBuilder<Action>> {
+    let mut builder = AclNetworkRuleBuilder::new_ingress(Action::default_forbid());
     builder.parse(value)?;
     Ok(builder)
 }

--- a/lib/g3-yaml/src/value/acl/proxy_request.rs
+++ b/lib/g3-yaml/src/value/acl/proxy_request.rs
@@ -16,30 +16,32 @@
 
 use yaml_rust::Yaml;
 
-use g3_types::acl::{AclAction, AclProxyRequestRule};
+use g3_types::acl::{AclProxyRequestRule, ActionContract};
 
 use super::AclRuleYamlParser;
 
-impl AclRuleYamlParser for AclProxyRequestRule {
+impl<Action: ActionContract> AclRuleYamlParser<Action> for AclProxyRequestRule<Action> {
     #[inline]
-    fn get_default_found_action(&self) -> AclAction {
-        AclAction::Permit
+    fn get_default_found_action(&self) -> Action {
+        Action::default_permit()
     }
 
     #[inline]
-    fn set_missed_action(&mut self, _action: AclAction) {
-        self.set_missed_action(_action);
+    fn set_missed_action(&mut self, action: Action) {
+        self.set_missed_action(action);
     }
 
-    fn add_rule_for_action(&mut self, action: AclAction, value: &Yaml) -> anyhow::Result<()> {
+    fn add_rule_for_action(&mut self, action: Action, value: &Yaml) -> anyhow::Result<()> {
         let t = crate::value::as_proxy_request_type(value)?;
         self.add_request_type(t, action);
         Ok(())
     }
 }
 
-pub fn as_proxy_request_rule(value: &Yaml) -> anyhow::Result<AclProxyRequestRule> {
-    let mut builder = AclProxyRequestRule::new(AclAction::Forbid);
+pub fn as_proxy_request_rule<Action: ActionContract>(
+    value: &Yaml,
+) -> anyhow::Result<AclProxyRequestRule<Action>> {
+    let mut builder = AclProxyRequestRule::new(Action::default_forbid());
     builder.parse(value)?;
     Ok(builder)
 }

--- a/lib/g3-yaml/src/value/acl/user_agent.rs
+++ b/lib/g3-yaml/src/value/acl/user_agent.rs
@@ -17,22 +17,22 @@
 use anyhow::Context;
 use yaml_rust::Yaml;
 
-use g3_types::acl::{AclAction, AclUserAgentRule};
+use g3_types::acl::{AclUserAgentRule, ActionContract};
 
 use super::AclRuleYamlParser;
 
-impl AclRuleYamlParser for AclUserAgentRule {
+impl<Action: ActionContract> AclRuleYamlParser<Action> for AclUserAgentRule<Action> {
     #[inline]
-    fn get_default_found_action(&self) -> AclAction {
-        AclAction::Forbid
+    fn get_default_found_action(&self) -> Action {
+        Action::default_forbid()
     }
 
     #[inline]
-    fn set_missed_action(&mut self, _action: AclAction) {
-        self.set_missed_action(_action);
+    fn set_missed_action(&mut self, action: Action) {
+        self.set_missed_action(action);
     }
 
-    fn add_rule_for_action(&mut self, action: AclAction, value: &Yaml) -> anyhow::Result<()> {
+    fn add_rule_for_action(&mut self, action: Action, value: &Yaml) -> anyhow::Result<()> {
         let ua_name = crate::value::as_ascii(value)
             .context("user-agent name should be valid ascii string")?;
         self.add_ua_name(ua_name.as_str(), action);
@@ -40,8 +40,10 @@ impl AclRuleYamlParser for AclUserAgentRule {
     }
 }
 
-pub fn as_user_agent_rule(value: &Yaml) -> anyhow::Result<AclUserAgentRule> {
-    let mut builder = AclUserAgentRule::new(AclAction::Permit);
+pub fn as_user_agent_rule<Action: ActionContract>(
+    value: &Yaml,
+) -> anyhow::Result<AclUserAgentRule<Action>> {
+    let mut builder = AclUserAgentRule::new(Action::default_permit());
     builder.parse(value)?;
     Ok(builder)
 }

--- a/lib/g3-yaml/src/value/acl_set/dst_host.rs
+++ b/lib/g3-yaml/src/value/acl_set/dst_host.rs
@@ -17,16 +17,14 @@
 use anyhow::{anyhow, Context};
 use yaml_rust::Yaml;
 
-use g3_types::acl_set::AclDstHostRuleSetBuilder;
+use g3_types::{acl::ActionContract, acl_set::AclDstHostRuleSetBuilder};
 
-pub fn as_dst_host_rule_set_builder(value: &Yaml) -> anyhow::Result<AclDstHostRuleSetBuilder> {
+pub fn as_dst_host_rule_set_builder<Action: ActionContract>(
+    value: &Yaml,
+) -> anyhow::Result<AclDstHostRuleSetBuilder<Action>> {
     if let Yaml::Hash(map) = value {
-        let mut builder = AclDstHostRuleSetBuilder {
-            exact: None,
-            child: None,
-            regex: None,
-            subnet: None,
-        };
+        let mut builder = AclDstHostRuleSetBuilder::default();
+
         crate::foreach_kv(map, |k, v| match crate::key::normalize(k).as_str() {
             "exact_match" | "exact" => {
                 let exact_rule = crate::value::acl::as_exact_host_rule(v)


### PR DESCRIPTION
Closes #341 

tested it with web sockets on a local g3 proxy, and it seems to work as expected:

```
websocket_inspect_policy:
      exact:
        default: intercept
        block:
          - "websocketstest.com"
```

Should work just as well for `h2_inspect_policy`, `smtp_inspect_policy` and `imap_inspect_policy`. But these I haven't tested. Code is same however.