### PR TITLE
fix: fix passphrase_hash json format

### DIFF
--- a/scripts/passphrase_hash.py
+++ b/scripts/passphrase_hash.py
@@ -5,6 +5,7 @@ import hashlib
 import argparse
 import secrets
 import binascii
+import json
 
 
 def is_float(s: str):
@@ -18,7 +19,7 @@ def is_float(s: str):
 def print_token(salt_s, md5_s, sha1_s, json_format=False):
     print("-=-=-=- for server -=-=-=-")
     if json_format:
-        print({'salt': salt_s, 'md5': md5_s, 'sha1': sha1_s})
+        print(json.dumps({'salt': salt_s, 'md5': md5_s, 'sha1': sha1_s}))
     else:
         print('salt:', salt_s)
         print('md5:', md5_s)


### PR DESCRIPTION
`scripts/passphrase_hash.py` has a option `--json` to output json format, but the output use ' which not a valid json format, this should be fixed then the output can be use directly.

![image](https://github.com/user-attachments/assets/ab8ca69d-7820-4f83-b4d0-630c77a1fcfd)
