### PR TITLE
g3proxy: support easy-proxy well-known uri in http_proxy server

### DIFF
--- a/g3proxy/examples/simple_http_proxy/g3proxy.yaml
+++ b/g3proxy/examples/simple_http_proxy/g3proxy.yaml
@@ -2,7 +2,7 @@
 runtime:
   thread_number: 1
 
-log: journal
+log: stdout
 
 stat:
   target_udp: 127.0.0.1:8125
@@ -14,6 +14,7 @@ server:
     listen:
       address: "[::]:10086"
     tls_client: { }
+    local_server_name: 127.0.0.1
     tcp_sock_speed_limit: 100M
   - name: test-tls
     tls_server:

--- a/g3proxy/src/serve/http_proxy/task/pipeline/reader.rs
+++ b/g3proxy/src/serve/http_proxy/task/pipeline/reader.rs
@@ -110,11 +110,9 @@ where
                 match tokio::time::timeout(
                     self.ctx.server_config.timeout.recv_req_header,
                     HttpProxyRequest::parse(
+                        &self.ctx.server_config,
                         &mut reader,
                         stream_sender.clone(),
-                        self.ctx.server_config.req_hdr_max_size,
-                        self.ctx.server_config.steal_forwarded_for,
-                        self.ctx.server_config.allow_custom_host,
                         &mut version,
                     ),
                 )

--- a/g3proxy/src/serve/http_proxy/task/pipeline/writer.rs
+++ b/g3proxy/src/serve/http_proxy/task/pipeline/writer.rs
@@ -24,9 +24,9 @@ use tokio::sync::mpsc;
 
 use g3_io_ext::{ArcLimitedWriterStats, LimitedWriter};
 use g3_types::auth::UserAuthError;
-use g3_types::net::{HttpAuth, HttpBasicAuth, HttpHeaderMap};
+use g3_types::net::{HttpAuth, HttpBasicAuth, HttpHeaderMap, HttpProxySubProtocol};
 
-use super::protocol::{HttpClientReader, HttpClientWriter, HttpProxyRequest, HttpProxySubProtocol};
+use super::protocol::{HttpClientReader, HttpClientWriter, HttpProxyRequest};
 use super::{
     CommonTaskContext, FtpOverHttpTask, HttpProxyCltWrapperStats, HttpProxyConnectTask,
     HttpProxyForwardTask, HttpProxyPipelineStats, HttpProxyUntrustedTask,

--- a/g3proxy/src/serve/http_proxy/task/protocol/request.rs
+++ b/g3proxy/src/serve/http_proxy/task/protocol/request.rs
@@ -20,9 +20,11 @@ use tokio::sync::mpsc;
 use tokio::time::Instant;
 
 use g3_http::server::{HttpProxyClientRequest, HttpRequestParseError, UriExt};
-use g3_types::net::UpstreamAddr;
+use g3_http::uri::WellKnownUri;
+use g3_types::net::{HttpProxySubProtocol, UpstreamAddr};
 
-use super::{HttpClientReader, HttpProxySubProtocol};
+use super::HttpClientReader;
+use crate::config::server::http_proxy::HttpProxyServerConfig;
 
 pub(crate) struct HttpProxyRequest<CDR> {
     pub(crate) client_protocol: HttpProxySubProtocol,
@@ -39,17 +41,18 @@ where
     CDR: AsyncRead + Unpin,
 {
     pub(crate) async fn parse(
+        config: &HttpProxyServerConfig,
         reader: &mut HttpClientReader<CDR>,
         sender: mpsc::Sender<Option<HttpClientReader<CDR>>>,
-        max_header_size: usize,
-        steal_forwarded_for: bool,
-        allow_custom_host: bool,
         version: &mut Version,
     ) -> Result<(Self, bool), HttpRequestParseError> {
         let time_accepted = Instant::now();
 
-        let req =
-            HttpProxyClientRequest::parse(reader, max_header_size, version, |req, name, header| {
+        let mut req = HttpProxyClientRequest::parse(
+            reader,
+            config.req_hdr_max_size,
+            version,
+            |req, name, header| {
                 match name.as_str() {
                     "proxy-authorization" => return req.parse_header_authorization(header.value),
                     "proxy-connection" => {
@@ -57,7 +60,7 @@ where
                         return req.parse_header_connection(header);
                     }
                     "forwarded" | "x-forwarded-for" => {
-                        if steal_forwarded_for {
+                        if config.steal_forwarded_for {
                             return Ok(());
                         }
                     }
@@ -65,8 +68,9 @@ where
                 }
                 req.append_header(name, header)?;
                 Ok(())
-            })
-            .await?;
+            },
+        )
+        .await?;
         let time_received = Instant::now();
 
         let (upstream, sub_protocol) = if matches!(&req.method, &Method::CONNECT) {
@@ -74,11 +78,39 @@ where
                 get_connect_upstream(&req.uri)?,
                 HttpProxySubProtocol::TcpConnect,
             )
+        } else if let Some(host) = &req.host {
+            if config.local_server_names.contains(host.host()) {
+                match WellKnownUri::parse(&req.uri) {
+                    Ok(Some(WellKnownUri::EasyProxy(protocol, addr, uri))) => {
+                        req.uri = uri;
+                        req.set_host(&addr);
+                        (addr, protocol)
+                    }
+                    Ok(Some(v)) => {
+                        return Err(HttpRequestParseError::UnsupportedRequest(format!(
+                            "unsupported well-known uri: {}",
+                            v.suffix()
+                        )));
+                    }
+                    Ok(None) => {
+                        return Err(HttpRequestParseError::UnsupportedRequest(
+                            "unsupported local request uri".to_string(),
+                        ));
+                    }
+                    Err(e) => {
+                        return Err(HttpRequestParseError::UnsupportedRequest(format!(
+                            "invalid well-known uri: {e}",
+                        )));
+                    }
+                }
+            } else {
+                get_forward_upstream_and_protocol(&req.uri)?
+            }
         } else {
             get_forward_upstream_and_protocol(&req.uri)?
         };
 
-        if !allow_custom_host {
+        if !config.allow_custom_host {
             if let Some(host) = &req.host {
                 if !host.host_eq(&upstream) {
                     return Err(HttpRequestParseError::UnmatchedHostAndAuthority);

--- a/lib/g3-http/src/server/error.rs
+++ b/lib/g3-http/src/server/error.rs
@@ -33,6 +33,8 @@ pub enum HttpRequestParseError {
     UnsupportedMethod(String),
     #[error("unsupported version: {0:?}")]
     UnsupportedVersion(Version),
+    #[error("unsupported well-known uri: {0}")]
+    UnsupportedRequest(String),
     #[error("invalid request target")]
     InvalidRequestTarget,
     #[error("invalid scheme")]
@@ -68,7 +70,8 @@ impl HttpRequestParseError {
             }
             HttpRequestParseError::UpgradeIsNotSupported
             | HttpRequestParseError::UnsupportedMethod(_)
-            | HttpRequestParseError::UnsupportedScheme => Some(StatusCode::NOT_IMPLEMENTED),
+            | HttpRequestParseError::UnsupportedScheme
+            | HttpRequestParseError::UnsupportedRequest(_) => Some(StatusCode::NOT_IMPLEMENTED),
             HttpRequestParseError::UnmatchedHostAndAuthority => Some(StatusCode::CONFLICT),
             HttpRequestParseError::LoopDetected => Some(StatusCode::LOOP_DETECTED),
             _ => Some(StatusCode::BAD_REQUEST),

--- a/lib/g3-http/src/server/request.rs
+++ b/lib/g3-http/src/server/request.rs
@@ -359,6 +359,16 @@ impl HttpProxyClientRequest {
         Ok(())
     }
 
+    pub fn set_host(&mut self, host: &UpstreamAddr) {
+        let mut new_v = unsafe { HttpHeaderValue::from_string_unchecked(host.to_string()) };
+        if let Some(old_v) = self.end_to_end_headers.remove(header::HOST) {
+            if let Some(name) = old_v.original_name() {
+                new_v.set_original_name(name);
+            }
+        }
+        self.end_to_end_headers.insert(header::HOST, new_v);
+    }
+
     fn insert_hop_by_hop_header(
         &mut self,
         name: HeaderName,

--- a/lib/g3-types/src/net/http/mod.rs
+++ b/lib/g3-types/src/net/http/mod.rs
@@ -18,10 +18,12 @@ mod auth;
 mod capability;
 mod header;
 mod keepalive;
+mod proxy;
 mod upgrade;
 
 pub use auth::{HttpAuth, HttpBasicAuth};
 pub use capability::*;
 pub use header::*;
 pub use keepalive::HttpKeepAliveConfig;
+pub use proxy::HttpProxySubProtocol;
 pub use upgrade::{HttpUpgradeToken, HttpUpgradeTokenParseError};

--- a/lib/g3-types/src/net/http/proxy/mod.rs
+++ b/lib/g3-types/src/net/http/proxy/mod.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 ByteDance and/or its affiliates.
+ * Copyright 2025 ByteDance and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,10 +14,5 @@
  * limitations under the License.
  */
 
-use g3_io_ext::{LimitedBufReader, LimitedWriter};
-
-mod request;
-pub(super) use request::HttpProxyRequest;
-
-pub(super) type HttpClientReader<CDR> = LimitedBufReader<CDR>;
-pub(super) type HttpClientWriter<CDW> = LimitedWriter<CDW>;
+mod protocol;
+pub use protocol::HttpProxySubProtocol;

--- a/lib/g3-types/src/net/http/proxy/protocol.rs
+++ b/lib/g3-types/src/net/http/proxy/protocol.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 ByteDance and/or its affiliates.
+ * Copyright 2025 ByteDance and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,10 +14,10 @@
  * limitations under the License.
  */
 
-use g3_io_ext::{LimitedBufReader, LimitedWriter};
-
-mod request;
-pub(super) use request::HttpProxyRequest;
-
-pub(super) type HttpClientReader<CDR> = LimitedBufReader<CDR>;
-pub(super) type HttpClientWriter<CDW> = LimitedWriter<CDW>;
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum HttpProxySubProtocol {
+    TcpConnect,
+    HttpForward,
+    HttpsForward,
+    FtpOverHttp,
+}

--- a/lib/g3-types/src/net/upstream.rs
+++ b/lib/g3-types/src/net/upstream.rs
@@ -228,6 +228,9 @@ impl FromStr for UpstreamAddr {
 
 impl fmt::Display for UpstreamAddr {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if self.port == 0 {
+            return self.host.fmt(f);
+        }
         match &self.host {
             Host::Ip(IpAddr::V4(ip4)) => write!(f, "{ip4}:{}", self.port),
             Host::Ip(IpAddr::V6(ip6)) => write!(f, "[{ip6}]:{}", self.port),

--- a/sphinx/g3proxy/configuration/servers/http_proxy.rst
+++ b/sphinx/g3proxy/configuration/servers/http_proxy.rst
@@ -51,6 +51,18 @@ The instance count setting will be ignored if *listen_in_worker* is correctly en
 
 .. versionadded:: 1.7.20 change listen config to be optional
 
+local_server_name
+-----------------
+
+**optional**, **type**: :ref:`host <conf_value_host>` | seq
+
+Set a list of local server names.
+
+If the host name sent in the `Host` request header matches the server names here, and the method is not `CONNECT`,
+then the request will be considered a local request.
+
+This must be set if you want to enable well-known URI support.
+
 .. _config_server_http_proxy_server_id:
 
 server_id


### PR DESCRIPTION
Initial support for easy-proxy well-known URI.

The specification is https://github.com/bytedance/g3/blob/master/doc/easy-proxy.md.

This will close https://github.com/bytedance/g3/issues/608.