### PR TITLE
test(g3-yaml): add unit tests for value/net/tcp.rs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -517,6 +517,7 @@ dependencies = [
  "android-tzdata",
  "iana-time-zone",
  "num-traits",
+ "serde",
  "windows-link",
 ]
 

--- a/lib/g3-yaml/Cargo.toml
+++ b/lib/g3-yaml/Cargo.toml
@@ -26,6 +26,9 @@ g3-compat = { workspace = true, optional = true }
 g3-dpi = { workspace = true, optional = true }
 g3-geoip-types = { workspace = true, optional = true }
 
+[dev-dependencies]
+chrono = { workspace = true, features = ["serde", "clock"] }
+
 [features]
 default = []
 histogram = ["dep:g3-histogram"]

--- a/lib/g3-yaml/src/value/net/tcp.rs
+++ b/lib/g3-yaml/src/value/net/tcp.rs
@@ -285,3 +285,415 @@ pub fn as_tcp_misc_sock_opts(v: &Yaml) -> anyhow::Result<TcpMiscSockOpts> {
         ))
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::net::{IpAddr, Ipv6Addr, SocketAddr};
+    use std::time::Duration;
+    use yaml_rust::{Yaml, YamlLoader};
+
+    use g3_types::net::{HappyEyeballsConfig, TcpConnectConfig, TcpKeepAliveConfig, TcpListenConfig, TcpMiscSockOpts};
+
+    // Helper to create Yaml from a string literal, panics on error.
+    fn yaml_from_str(s: &str) -> Yaml {
+        YamlLoader::load_from_str(s).unwrap()[0].clone()
+    }
+
+    mod test_as_tcp_listen_config {
+        use super::*;
+
+        #[test]
+        fn integer_port() {
+            let yaml = yaml_from_str("8080");
+            let config = as_tcp_listen_config(&yaml).unwrap();
+            assert_eq!(config.address().port(), 8080);
+            assert_eq!(
+                config.address(),
+                SocketAddr::new(IpAddr::V6(Ipv6Addr::UNSPECIFIED), 8080)
+            );
+        }
+
+        #[test]
+        fn string_address() {
+            let yaml = yaml_from_str("\"127.0.0.1:8081\"");
+            let config = as_tcp_listen_config(&yaml).unwrap();
+            let expected_addr: SocketAddr = "127.0.0.1:8081".parse().unwrap();
+            assert_eq!(config.address(), expected_addr);
+        }
+
+        #[test]
+        fn hash_full() {
+            let yaml_str = r#"
+                address: "0.0.0.0:8083"
+                backlog: 1024
+                scale: "50%"
+            "#;
+            let yaml = yaml_from_str(yaml_str);
+            let config = as_tcp_listen_config(&yaml).unwrap();
+
+            let expected_addr: SocketAddr = "0.0.0.0:8083".parse().unwrap();
+            assert_eq!(config.address(), expected_addr);
+            assert_eq!(config.backlog(), 1024);
+        }
+
+        #[cfg(not(target_os = "openbsd"))]
+        #[test]
+        fn hash_ipv6_only_true() {
+            let yaml_str = r#"
+                address: "[::]:8083"
+                ipv6_only: true
+            "#;
+            let yaml = yaml_from_str(yaml_str);
+            let config = as_tcp_listen_config(&yaml).unwrap();
+            assert_eq!(config.is_ipv6only(), Some(true));
+        }
+
+        #[cfg(not(target_os = "openbsd"))]
+        #[test]
+        fn hash_ipv6_only_false() {
+            let yaml_str = r#"
+                address: "[::]:8084"
+                ipv6_only: false
+            "#;
+            let yaml = yaml_from_str(yaml_str);
+            let config = as_tcp_listen_config(&yaml).unwrap();
+            assert_eq!(config.is_ipv6only(), Some(false));
+        }
+
+        #[test]
+        fn scale_percentage() {
+            let yaml_map = yaml_from_str("scale: \"50%\"");
+            let mut cfg = TcpListenConfig::default();
+            assert!(set_tcp_listen_scale(&mut cfg, &yaml_map["scale"]).is_ok());
+        }
+
+        #[test]
+        fn scale_fraction() {
+            let yaml_map = yaml_from_str("scale: \"3/4\"");
+            let mut cfg = TcpListenConfig::default();
+            assert!(set_tcp_listen_scale(&mut cfg, &yaml_map["scale"]).is_ok());
+        }
+
+        #[test]
+        fn scale_float_str() {
+            let yaml_map = yaml_from_str("scale: \"1.5\"");
+            let mut cfg = TcpListenConfig::default();
+            assert!(set_tcp_listen_scale(&mut cfg, &yaml_map["scale"]).is_ok());
+        }
+
+        #[test]
+        fn scale_integer() {
+            let yaml_map = yaml_from_str("scale: 2");
+            let mut cfg = TcpListenConfig::default();
+            assert!(set_tcp_listen_scale(&mut cfg, &yaml_map["scale"]).is_ok());
+        }
+
+        #[test]
+        fn scale_real() {
+            let yaml_value = Yaml::Real("2.5".to_string());
+            let mut cfg = TcpListenConfig::default();
+            assert!(set_tcp_listen_scale(&mut cfg, &yaml_value).is_ok());
+        }
+
+        #[test]
+        fn invalid_port_too_large() {
+            let yaml = yaml_from_str("70000");
+            assert!(as_tcp_listen_config(&yaml).is_err());
+        }
+
+        #[test]
+        fn invalid_address_format() {
+            let yaml = yaml_from_str("\"not_an_address\"");
+            assert!(as_tcp_listen_config(&yaml).is_err());
+        }
+        
+        #[test]
+        fn invalid_scale_type_bool() {
+            let yaml_map = yaml_from_str("scale: true");
+            let mut cfg = TcpListenConfig::default();
+            assert!(set_tcp_listen_scale(&mut cfg, &yaml_map["scale"]).is_err());
+        }
+
+        #[test]
+        fn invalid_scale_percentage_format() {
+            let yaml_map = yaml_from_str("scale: \"abc%\"");
+            let mut cfg = TcpListenConfig::default();
+            assert!(set_tcp_listen_scale(&mut cfg, &yaml_map["scale"]).is_err());
+        }
+
+        #[test]
+        fn invalid_scale_fraction_numerator() {
+            let yaml_map = yaml_from_str("scale: \"a/4\"");
+            let mut cfg = TcpListenConfig::default();
+            assert!(set_tcp_listen_scale(&mut cfg, &yaml_map["scale"]).is_err());
+        }
+
+        #[test]
+        fn invalid_scale_fraction_denominator() {
+            let yaml_map = yaml_from_str("scale: \"3/b\"");
+            let mut cfg = TcpListenConfig::default();
+            assert!(set_tcp_listen_scale(&mut cfg, &yaml_map["scale"]).is_err());
+        }
+
+        #[test]
+        fn invalid_scale_float_str_format() {
+            let yaml_map = yaml_from_str("scale: \"not_a_float\"");
+            let mut cfg = TcpListenConfig::default();
+            assert!(set_tcp_listen_scale(&mut cfg, &yaml_map["scale"]).is_err());
+        }
+
+        #[test]
+        fn invalid_hash_key() {
+            let yaml_str = "invalid_key: 123";
+            let yaml = yaml_from_str(yaml_str);
+            assert!(as_tcp_listen_config(&yaml).is_err());
+        }
+
+        #[test]
+        fn invalid_top_level_type_array() {
+            let yaml_str = "[1, 2, 3]";
+            let yaml = yaml_from_str(yaml_str);
+            assert!(as_tcp_listen_config(&yaml).is_err());
+        }
+    }
+
+    mod test_as_tcp_connect_config {
+        use super::*;
+
+        #[test]
+        fn normal_input() {
+            let yaml_str = r#"
+                max_retry: 5
+                each_timeout: 10s
+            "#;
+            let yaml = yaml_from_str(yaml_str);
+            let config = as_tcp_connect_config(&yaml).unwrap();
+            assert_eq!(config.max_tries(), 6); 
+            assert_eq!(config.each_timeout(), Duration::from_secs(10));
+        }
+
+        #[test]
+        fn default_values() {
+            let yaml_str = "{}";
+            let yaml = yaml_from_str(yaml_str);
+            let config = as_tcp_connect_config(&yaml).unwrap();
+            let default_config = TcpConnectConfig::default();
+            assert_eq!(config.max_tries(), default_config.max_tries());
+            assert_eq!(config.each_timeout(), default_config.each_timeout());
+        }
+
+        #[test]
+        fn invalid_type_not_map() {
+            let yaml = yaml_from_str("123");
+            assert!(as_tcp_connect_config(&yaml).is_err());
+        }
+
+        #[test]
+        fn invalid_key() {
+            let yaml_str = "unknown_key: 100";
+            let yaml = yaml_from_str(yaml_str);
+            assert!(as_tcp_connect_config(&yaml).is_err());
+        }
+
+        #[test]
+        fn invalid_max_retry_type() {
+            let yaml_str = "max_retry: \"not_a_number\"";
+            let yaml = yaml_from_str(yaml_str);
+            assert!(as_tcp_connect_config(&yaml).is_err());
+        }
+
+        #[test]
+        fn invalid_each_timeout_type() {
+            let yaml_str = "each_timeout: \"not_a_duration\"";
+            let yaml = yaml_from_str(yaml_str);
+            assert!(as_tcp_connect_config(&yaml).is_err());
+        }
+    }
+
+    mod test_as_happy_eyeballs_config {
+        use super::*;
+
+        #[test]
+        fn normal_input() {
+            let yaml_str = r#"
+                resolution_delay: 50ms
+                second_resolution_timeout: 1s
+                first_address_family_count: 2
+                connection_attempt_delay: 25ms
+            "#;
+            let yaml = yaml_from_str(yaml_str);
+            let config = as_happy_eyeballs_config(&yaml).unwrap();
+            assert_eq!(config.resolution_delay(), Duration::from_millis(50));
+            assert_eq!(config.second_resolution_timeout(), Duration::from_secs(1));
+            assert_eq!(config.first_address_family_count(), 2);
+        }
+
+        #[test]
+        fn default_values() {
+            let yaml_str = "{}";
+            let yaml = yaml_from_str(yaml_str);
+            let config = as_happy_eyeballs_config(&yaml).unwrap();
+            let default_config = HappyEyeballsConfig::default();
+            assert_eq!(config.resolution_delay(), default_config.resolution_delay());
+            assert_eq!(
+                config.second_resolution_timeout(),
+                default_config.second_resolution_timeout()
+            );
+            assert_eq!(
+                config.first_address_family_count(),
+                default_config.first_address_family_count()
+            );
+            assert_eq!(
+                config.connection_attempt_delay(),
+                default_config.connection_attempt_delay()
+            );
+        }
+
+        #[test]
+        fn invalid_type_not_map() {
+            let yaml = yaml_from_str("\"string_value\"");
+            assert!(as_happy_eyeballs_config(&yaml).is_err());
+        }
+
+        #[test]
+        fn invalid_key() {
+            let yaml_str = "bad_key: true";
+            let yaml = yaml_from_str(yaml_str);
+            assert!(as_happy_eyeballs_config(&yaml).is_err());
+        }
+
+        #[test]
+        fn invalid_negative_delay() {
+            let yaml_str = "resolution_delay: \"-1s\"";
+            let yaml = yaml_from_str(yaml_str);
+            assert!(as_happy_eyeballs_config(&yaml).is_err());
+        }
+    }
+
+    mod test_as_tcp_keepalive_config {
+        use super::*;
+
+        #[test]
+        fn hash_input_full() {
+            let yaml_str = r#"
+                enable: true
+                idle_time: 300s
+                probe_interval: 10s
+                probe_count: 5
+            "#;
+            let yaml = yaml_from_str(yaml_str);
+            let config = as_tcp_keepalive_config(&yaml).unwrap();
+            assert!(config.is_enabled());
+            assert_eq!(config.idle_time(), Duration::from_secs(300));
+            assert_eq!(config.probe_interval(), Some(Duration::from_secs(10)));
+            assert_eq!(config.probe_count(), Some(5));
+        }
+
+        #[test]
+        fn boolean_input_true() {
+            let yaml = yaml_from_str("true");
+            let config = as_tcp_keepalive_config(&yaml).unwrap();
+            assert!(config.is_enabled());
+            let default_tcp_ka_config = TcpKeepAliveConfig::default();
+            assert_eq!(config.idle_time(), default_tcp_ka_config.idle_time());
+        }
+
+        #[test]
+        fn boolean_input_false() {
+            let yaml = yaml_from_str("false");
+            let config = as_tcp_keepalive_config(&yaml).unwrap();
+            assert!(!config.is_enabled());
+        }
+
+        #[test]
+        fn duration_string_input() {
+            let yaml = yaml_from_str("\"120s\"");
+            let config = as_tcp_keepalive_config(&yaml).unwrap();
+            assert!(config.is_enabled());
+            assert_eq!(config.idle_time(), Duration::from_secs(120));
+        }
+
+        #[test]
+        fn hash_input_only_enable_false() {
+            let yaml_str = "enable: false";
+            let yaml = yaml_from_str(yaml_str);
+            let config = as_tcp_keepalive_config(&yaml).unwrap();
+            assert!(!config.is_enabled());
+        }
+
+        #[test]
+        fn invalid_hash_key() {
+            let yaml_str = "unknown_field: 10s";
+            let yaml = yaml_from_str(yaml_str);
+            assert!(as_tcp_keepalive_config(&yaml).is_err());
+        }
+    }
+
+    mod test_as_tcp_misc_sock_opts {
+        use super::*;
+
+        #[test]
+        fn normal_input_full() {
+            let yaml_str = r#"
+                no_delay: true
+                max_segment_size: 1460
+                time_to_live: 64
+                type_of_service: 0x10
+            "#;
+            let yaml = yaml_from_str(yaml_str);
+            let config = as_tcp_misc_sock_opts(&yaml).unwrap();
+            assert_eq!(config.no_delay, Some(true));
+            assert_eq!(config.max_segment_size, Some(1460));
+            assert_eq!(config.time_to_live, Some(64));
+            assert_eq!(config.type_of_service, Some(0x10));
+        }
+
+        #[test]
+        fn default_values() {
+            let yaml_str = "{}";
+            let yaml = yaml_from_str(yaml_str);
+            let config = as_tcp_misc_sock_opts(&yaml).unwrap();
+            let default_config = TcpMiscSockOpts::default();
+            assert_eq!(config.no_delay, default_config.no_delay);
+            assert_eq!(config.max_segment_size, default_config.max_segment_size);
+            assert_eq!(config.time_to_live, default_config.time_to_live);
+            assert_eq!(config.type_of_service, default_config.type_of_service);
+            assert_eq!(config.netfilter_mark, default_config.netfilter_mark);
+        }
+
+        #[test]
+        fn invalid_type_not_map() {
+            let yaml = yaml_from_str("\"some_string\"");
+            assert!(as_tcp_misc_sock_opts(&yaml).is_err());
+        }
+
+        #[test]
+        fn invalid_key() {
+            let yaml_str = "unsupported_opt: 1";
+            let yaml = yaml_from_str(yaml_str);
+            assert!(as_tcp_misc_sock_opts(&yaml).is_err());
+        }
+
+        #[test]
+        fn invalid_no_delay_type() {
+            let yaml_str = "no_delay: \"true_string\"";
+            let yaml = yaml_from_str(yaml_str);
+            assert!(as_tcp_misc_sock_opts(&yaml).is_err());
+        }
+
+        #[test]
+        fn invalid_mss_type() {
+            let yaml_str = "max_segment_size: \"1460s\"";
+            let yaml = yaml_from_str(yaml_str);
+            assert!(as_tcp_misc_sock_opts(&yaml).is_err());
+        }
+
+        #[test]
+        fn invalid_tos_type() {
+            let yaml_str = "type_of_service: \"not_u8\"";
+            let yaml = yaml_from_str(yaml_str);
+            assert!(as_tcp_misc_sock_opts(&yaml).is_err());
+        }
+    }
+}


### PR DESCRIPTION
### Changes Made

1. Add comprehensive unit tests for `set_tcp_listen_scale` function in `test_as_tcp_listen_config`:

- Normal input tests:
  - Percentage format (e.g., "50%")
  - Fraction format (e.g., "3/4")
  - String float format (e.g., "1.5")
  - Integer input
  - Real number input

- Error case tests:
  - Boolean type error
  - Invalid percentage format
  - Invalid fraction format
  - Invalid float string format

2. Add unit tests for each `as_*_config` function in `test_as_*_config`

- Cover various input types

3. Fix chrono dependency configuration in Cargo.toml

### Test Verification

All tests have passed:
```bash
cargo test --package g3-yaml --lib -- value::net::tcp::tests
```

### Related Issue
 #605 