### PR TITLE
g3-proxy: add tcp keepalive to std listener

### DIFF
--- a/lib/g3-socket/src/tcp.rs
+++ b/lib/g3-socket/src/tcp.rs
@@ -46,6 +46,13 @@ pub fn new_std_listener(config: &TcpListenConfig) -> io::Result<std::net::TcpLis
     if let Some(iface) = config.interface() {
         socket.bind_device(Some(iface.c_bytes()))?;
     }
+
+    if let Some(tcpkeepalive_config) = config.tcp_keepalive() {
+        if let Some(setting) = enable_tcp_keepalive(tcpkeepalive_config) {
+            socket.set_tcp_keepalive(&setting)?;
+        }
+    }
+
     #[cfg(any(target_os = "macos", target_os = "illumos", target_os = "solaris"))]
     if let Some(iface) = config.interface() {
         match family {
@@ -67,26 +74,31 @@ pub fn new_std_socket_to(
     let peer_family = AddressFamily::from(&peer_ip);
     let socket = new_tcp_socket(peer_family)?;
     bind.bind_tcp_for_connect(&socket, peer_family)?;
-    #[cfg(not(target_os = "openbsd"))]
-    if keepalive.is_enabled() {
-        // set keepalive_idle
-        let mut setting = TcpKeepalive::new().with_time(keepalive.idle_time());
-        if let Some(interval) = keepalive.probe_interval() {
-            setting = setting.with_interval(interval);
-        }
-        if let Some(count) = keepalive.probe_count() {
-            setting = setting.with_retries(count);
-        }
+
+    if let Some(setting) = enable_tcp_keepalive(keepalive) {
         socket.set_tcp_keepalive(&setting)?;
     }
-    #[cfg(target_os = "openbsd")]
-    if keepalive.is_enabled() {
-        // set keepalive_idle
-        let setting = TcpKeepalive::new().with_time(keepalive.idle_time());
-        socket.set_tcp_keepalive(&setting)?;
-    }
+
     RawSocket::from(&socket).set_tcp_misc_opts(peer_family, misc_opts, default_set_nodelay)?;
     Ok(std::net::TcpStream::from(socket))
+}
+
+fn enable_tcp_keepalive(config: &TcpKeepAliveConfig) -> Option<TcpKeepalive> {
+    if config.is_enabled() {
+        let mut setting = TcpKeepalive::new().with_time(config.idle_time());
+        #[cfg(not(target_os = "openbsd"))]
+        {
+            if let Some(interval) = config.probe_interval() {
+                setting = setting.with_interval(interval);
+            }
+            if let Some(count) = config.probe_count() {
+                setting = setting.with_retries(count);
+            }
+        }
+        Some(setting)
+    } else {
+        None
+    }
 }
 
 #[cfg(any(windows, target_os = "macos"))]

--- a/lib/g3-types/src/net/tcp/listen.rs
+++ b/lib/g3-types/src/net/tcp/listen.rs
@@ -16,6 +16,7 @@ use num_traits::ToPrimitive;
     target_os = "solaris"
 ))]
 use crate::net::Interface;
+use crate::net::TcpKeepAliveConfig;
 
 const DEFAULT_LISTEN_BACKLOG: u32 = 4096;
 const MINIMAL_LISTEN_BACKLOG: u32 = 8;
@@ -41,6 +42,7 @@ pub struct TcpListenConfig {
     instance: usize,
     scale: usize,
     follow_cpu_affinity: bool,
+    tcp_keepalive: Option<TcpKeepAliveConfig>,
 }
 
 impl Default for TcpListenConfig {
@@ -71,6 +73,7 @@ impl TcpListenConfig {
             instance: 1,
             scale: 0,
             follow_cpu_affinity: false,
+            tcp_keepalive: None,
         }
     }
 
@@ -109,6 +112,11 @@ impl TcpListenConfig {
     #[inline]
     pub fn transparent(&self) -> bool {
         self.transparent
+    }
+
+    #[inline]
+    pub fn tcp_keepalive(&self) -> Option<&TcpKeepAliveConfig> {
+        self.tcp_keepalive.as_ref()
     }
 
     #[cfg(any(target_os = "android", target_os = "fuchsia", target_os = "linux"))]
@@ -172,6 +180,11 @@ impl TcpListenConfig {
         if backlog >= MINIMAL_LISTEN_BACKLOG {
             self.backlog = backlog;
         }
+    }
+
+    #[inline]
+    pub fn set_tcp_keepalive(&mut self, tcp_keep_alive_config: TcpKeepAliveConfig) {
+        self.tcp_keepalive = Some(tcp_keep_alive_config);
     }
 
     pub fn set_instance(&mut self, instance: usize) {

--- a/lib/g3-yaml/src/value/net/tcp.rs
+++ b/lib/g3-yaml/src/value/net/tcp.rs
@@ -125,6 +125,12 @@ pub fn as_tcp_listen_config(value: &Yaml) -> anyhow::Result<TcpListenConfig> {
                     config.set_follow_cpu_affinity(enable);
                     Ok(())
                 }
+                "tcp_keepalive" => {
+                    let tcp_keepalive = as_tcp_keepalive_config(v)
+                        .context(format!("invalid tcp keepalive config value for key {k}"))?;
+                    config.set_tcp_keepalive(tcp_keepalive);
+                    Ok(())
+                }
                 _ => Err(anyhow!("invalid key {k}")),
             })?;
         }

--- a/sphinx/g3proxy/configuration/values/network.rst
+++ b/sphinx/g3proxy/configuration/values/network.rst
@@ -290,6 +290,16 @@ It consists of the following fields:
 
   .. versionadded:: 1.11.6
 
+* tcp_keepalive
+
+  **optional**, **type**: :ref:`tcp keepalive <conf_value_tcp_keepalive>`
+
+  Set the keep-alive config for the listing tcp socket.
+
+  **default**: not set
+
+  .. versionadded:: 1.11.10
+
 * backlog
 
   **optional**, **type**: unsigned int


### PR DESCRIPTION
Add optional tcp keep alive settings to the std listener socket. 