### PR TITLE
g3-yaml: add unit tests for YAML value parsers

### DIFF
--- a/lib/g3-yaml/src/value/histogram.rs
+++ b/lib/g3-yaml/src/value/histogram.rs
@@ -75,3 +75,112 @@ pub fn as_histogram_metrics_config(value: &Yaml) -> anyhow::Result<HistogramMetr
         Ok(HistogramMetricsConfig::with_rotate(rotate))
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Duration;
+    use yaml_rust::YamlLoader;
+
+    #[test]
+    fn as_quantile_ok() {
+        // valid string quantiles
+        assert_eq!(as_quantile(&yaml_str!("0.5")).unwrap().value(), 0.5);
+        assert_eq!(as_quantile(&yaml_str!("0.99")).unwrap().value(), 0.99);
+
+        // valid float quantiles
+        assert_eq!(as_quantile(&Yaml::Real("0.5".into())).unwrap().value(), 0.5);
+        assert_eq!(
+            as_quantile(&Yaml::Real("0.99".into())).unwrap().value(),
+            0.99
+        );
+    }
+
+    #[test]
+    fn as_quantile_err() {
+        // invalid types
+        assert!(as_quantile(&Yaml::Integer(1)).is_err());
+        assert!(as_quantile(&Yaml::Boolean(true)).is_err());
+
+        // out-of-range values
+        assert!(as_quantile(&yaml_str!("-0.1")).is_err());
+        assert!(as_quantile(&yaml_str!("1.1")).is_err());
+
+        // malformed strings
+        assert!(as_quantile(&yaml_str!("abc")).is_err());
+    }
+
+    #[test]
+    fn as_quantile_list_ok() {
+        // comma-separated string
+        let list = as_quantile_list(&yaml_str!("0.5, 0.75, 0.99")).unwrap();
+        assert_eq!(list.len(), 3);
+        assert!(list.contains(&Quantile::from_str("0.5").unwrap()));
+        assert!(list.contains(&Quantile::from_str("0.75").unwrap()));
+        assert!(list.contains(&Quantile::from_str("0.99").unwrap()));
+
+        // array format
+        let yaml = yaml_doc!("- 0.5\n- 0.75\n- 0.99");
+        let list = as_quantile_list(&yaml).unwrap();
+        assert_eq!(list.len(), 3);
+        assert!(list.contains(&Quantile::from_str("0.5").unwrap()));
+        assert!(list.contains(&Quantile::from_str("0.75").unwrap()));
+        assert!(list.contains(&Quantile::from_str("0.99").unwrap()));
+    }
+
+    #[test]
+    fn as_quantile_list_err() {
+        // invalid string format
+        assert!(as_quantile_list(&yaml_str!("0.5;0.75")).is_err());
+
+        // array with invalid elements
+        let yaml = yaml_doc!("- 0.5\n- invalid\n- 0.99");
+        assert!(as_quantile_list(&yaml).is_err());
+
+        // invalid type
+        assert!(as_quantile_list(&Yaml::Boolean(true)).is_err());
+    }
+
+    #[test]
+    fn as_histogram_metrics_config_ok() {
+        // simplified form (duration only)
+        let config = as_histogram_metrics_config(&yaml_str!("10s")).unwrap();
+        let expected = HistogramMetricsConfig::with_rotate(Duration::from_secs(10));
+        assert_eq!(config.rotate_interval(), expected.rotate_interval());
+
+        // full form with quantiles
+        let yaml = yaml_doc!("quantile: 0.5,0.99\nrotate: 5s");
+        let config = as_histogram_metrics_config(&yaml).unwrap();
+        let mut expected = HistogramMetricsConfig::default();
+        let mut quantile_list = BTreeSet::new();
+        quantile_list.insert(Quantile::from_str("0.5").unwrap());
+        quantile_list.insert(Quantile::from_str("0.99").unwrap());
+        expected.set_quantile_list(quantile_list);
+        expected.set_rotate_interval(Duration::from_secs(5));
+        assert_eq!(config, expected);
+
+        // other valid formats
+        let yaml = Yaml::Integer(10);
+        let config = as_histogram_metrics_config(&yaml).unwrap();
+        let expected = HistogramMetricsConfig::with_rotate(Duration::from_secs(10));
+        assert_eq!(config.rotate_interval(), expected.rotate_interval());
+    }
+
+    #[test]
+    fn as_histogram_metrics_config_err() {
+        // invalid keys
+        let yaml = yaml_doc!("invalid_key: value");
+        assert!(as_histogram_metrics_config(&yaml).is_err());
+
+        // invalid duration format
+        assert!(as_histogram_metrics_config(&yaml_str!("invalid")).is_err());
+
+        // invalid quantile format
+        let yaml = yaml_doc!("quantile: invalid\nrotate: 5s");
+        assert!(as_histogram_metrics_config(&yaml).is_err());
+
+        // non-hash input
+        let yaml = Yaml::Null;
+        assert!(as_histogram_metrics_config(&yaml).is_err());
+    }
+}

--- a/lib/g3-yaml/src/value/quinn.rs
+++ b/lib/g3-yaml/src/value/quinn.rs
@@ -52,3 +52,118 @@ pub fn as_quinn_transport_config(value: &Yaml) -> anyhow::Result<QuinnTransportC
     })?;
     Ok(config)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Duration;
+    use yaml_rust::YamlLoader;
+
+    #[test]
+    fn as_quinn_transport_config_ok() {
+        // full configuration
+        let yaml = yaml_doc!(
+            r#"
+                max_idle_timeout: "60s"
+                keep_alive_interval: "10s"
+                stream_receive_window: 65535
+                receive_window: 131072
+                send_window: 262144
+            "#
+        );
+        let config = as_quinn_transport_config(&yaml).unwrap();
+        let mut expected = QuinnTransportConfigBuilder::default();
+        expected
+            .set_max_idle_timeout(Duration::from_secs(60))
+            .unwrap();
+        expected.set_keep_alive_interval(Duration::from_secs(10));
+        expected.set_stream_receive_window(65535);
+        expected.set_receive_window(131072);
+        expected.set_send_window(262144);
+        assert_eq!(config, expected);
+
+        // default configuration
+        let yaml = Yaml::Hash(Default::default());
+        let config = as_quinn_transport_config(&yaml).unwrap();
+        let mut expected = QuinnTransportConfigBuilder::default();
+        expected
+            .set_max_idle_timeout(Duration::from_secs(60))
+            .unwrap();
+        expected.set_keep_alive_interval(Duration::from_secs(10));
+        assert_eq!(config, expected);
+
+        // boundary values
+        let yaml = yaml_doc!(
+            r#"
+                stream_receive_window: 1
+                receive_window: 1
+                send_window: 1
+            "#
+        );
+        let config = as_quinn_transport_config(&yaml).unwrap();
+        let mut expected = QuinnTransportConfigBuilder::default();
+        expected.set_stream_receive_window(1);
+        expected.set_receive_window(1);
+        expected.set_send_window(1);
+        assert_eq!(config, expected);
+    }
+
+    #[test]
+    fn as_quinn_transport_config_err() {
+        // invalid key
+        let yaml = yaml_doc!(
+            r#"
+                invalid_key: "value"
+            "#
+        );
+        assert!(as_quinn_transport_config(&yaml).is_err());
+
+        // non-hash input
+        let yaml = yaml_doc!(
+            r#"
+                - item1
+                - item2
+            "#
+        );
+        assert!(as_quinn_transport_config(&yaml).is_err());
+
+        let yaml = Yaml::Boolean(true);
+        assert!(as_quinn_transport_config(&yaml).is_err());
+
+        // invalid value type
+        let yaml = yaml_doc!(
+            r#"
+                max_idle_timeout: "invalid"
+            "#
+        );
+        assert!(as_quinn_transport_config(&yaml).is_err());
+
+        let yaml = yaml_doc!(
+            r#"
+                keep_alive_interval: "1x"
+            "#
+        );
+        assert!(as_quinn_transport_config(&yaml).is_err());
+
+        let yaml = yaml_doc!(
+            r#"
+                stream_receive_window: "not_a_number"
+            "#
+        );
+        assert!(as_quinn_transport_config(&yaml).is_err());
+
+        let yaml = yaml_doc!(
+            r#"
+                receive_window: -1
+            "#
+        );
+        assert!(as_quinn_transport_config(&yaml).is_err());
+
+        let yaml = yaml_doc!(
+            r#"
+                send_window: 1y
+            "#
+        );
+        assert!(as_quinn_transport_config(&yaml).is_err());
+    }
+}

--- a/lib/g3-yaml/src/value/regex.rs
+++ b/lib/g3-yaml/src/value/regex.rs
@@ -17,3 +17,29 @@ pub fn as_regex(value: &Yaml) -> anyhow::Result<Regex> {
         ))
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn as_regex_ok() {
+        // valid regex string
+        let yaml = yaml_str!("^\\d{3}-\\d{2}-\\d{4}$");
+        assert_eq!(as_regex(&yaml).unwrap().as_str(), "^\\d{3}-\\d{2}-\\d{4}$");
+
+        let yaml = yaml_str!("^[a-zA-Z]+$");
+        assert_eq!(as_regex(&yaml).unwrap().as_str(), "^[a-zA-Z]+$");
+    }
+
+    #[test]
+    fn as_regex_err() {
+        // invalid regex string
+        let yaml = yaml_str!("^\\d{3-\\d{2}-\\d{4}$");
+        assert!(as_regex(&yaml).is_err());
+
+        // non-string type
+        let yaml = Yaml::Integer(123);
+        assert!(as_regex(&yaml).is_err());
+    }
+}

--- a/lib/g3-yaml/src/value/rustls.rs
+++ b/lib/g3-yaml/src/value/rustls.rs
@@ -299,3 +299,499 @@ pub fn as_rustls_server_config_builder(
         ))
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use std::path::{Path, PathBuf};
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::time::Duration;
+    use yaml_rust::YamlLoader;
+
+    const TEST_CERT_PEM: &str = include_str!("./test_data/test_cert1.pem");
+    const TEST_KEY_PEM: &str = include_str!("./test_data/test_key1.pem");
+
+    static TEST_DIR_ID_COUNTER: AtomicUsize = AtomicUsize::new(0);
+
+    struct TempDir {
+        path: PathBuf,
+    }
+
+    impl TempDir {
+        fn new(prefix: &str) -> Self {
+            let id = TEST_DIR_ID_COUNTER.fetch_add(1, Ordering::SeqCst);
+            let path =
+                std::env::temp_dir().join(format!("{}_{}_{}", prefix, std::process::id(), id));
+            fs::create_dir_all(&path).expect("Failed to create test directory");
+            TempDir { path }
+        }
+
+        fn path(&self) -> &Path {
+            &self.path
+        }
+    }
+
+    impl Drop for TempDir {
+        fn drop(&mut self) {
+            let _ = fs::remove_dir_all(&self.path);
+        }
+    }
+
+    #[test]
+    fn as_rustls_server_name_ok() {
+        // valid DNS name
+        let yaml = yaml_str!("example.com");
+        assert_eq!(
+            as_rustls_server_name(&yaml).unwrap(),
+            ServerName::try_from("example.com").unwrap()
+        );
+
+        // valid IP address
+        let yaml = yaml_str!("192.168.0.1");
+        assert_eq!(
+            as_rustls_server_name(&yaml).unwrap(),
+            ServerName::try_from("192.168.0.1").unwrap()
+        );
+    }
+
+    #[test]
+    fn as_rustls_server_name_err() {
+        // non-string YAML
+        let yaml = Yaml::Integer(123);
+        assert!(as_rustls_server_name(&yaml).is_err());
+
+        // empty string
+        let yaml = yaml_str!("");
+        assert!(as_rustls_server_name(&yaml).is_err());
+
+        // invalid DNS name
+        let yaml = yaml_str!("invalid domain");
+        assert!(as_rustls_server_name(&yaml).is_err());
+
+        // invalid IP address
+        let yaml = yaml_str!("192.168.0.256");
+        assert!(as_rustls_server_name(&yaml).is_err());
+    }
+
+    #[test]
+    fn as_rustls_certificates_ok() {
+        let temp_dir = TempDir::new("rustls_cert_ok");
+        let test_dir_path = temp_dir.path();
+        let cert_path = test_dir_path.join("test_cert.pem");
+        fs::write(&cert_path, TEST_CERT_PEM).unwrap();
+
+        // single PEM string
+        let yaml = Yaml::String(TEST_CERT_PEM.to_string());
+        let certs = as_rustls_certificates(&yaml, None).unwrap();
+        assert!(!certs.is_empty());
+
+        // file path
+        let yaml = YamlLoader::load_from_str(&format!("|-\n  {}", cert_path.display())).unwrap();
+        let certs = as_rustls_certificates(&yaml[0], Some(temp_dir.path())).unwrap();
+        assert!(!certs.is_empty());
+
+        // array of PEM strings
+        let yaml = Yaml::Array(vec![
+            Yaml::String(TEST_CERT_PEM.to_string()),
+            Yaml::String(TEST_CERT_PEM.to_string()),
+        ]);
+        let certs = as_rustls_certificates(&yaml, None).unwrap();
+        assert_eq!(certs.len(), 2);
+    }
+
+    #[test]
+    fn as_rustls_certificates_err() {
+        // invalid PEM string
+        let yaml = yaml_str!("invalid cert");
+        assert!(as_rustls_certificates(&yaml, None).is_err());
+
+        // non-existent file
+        let yaml = yaml_str!("non_existent_cert.pem");
+        assert!(as_rustls_certificates(&yaml, Some(Path::new("/non_existent"))).is_err());
+
+        // empty array
+        let yaml = yaml_doc!(r#"- []"#);
+        assert!(as_rustls_certificates(&yaml, None).is_err());
+
+        // array with invalid PEM
+        let yaml = Yaml::Array(vec![
+            Yaml::String("invalid cert".to_string()),
+            Yaml::String(TEST_CERT_PEM.to_string()),
+        ]);
+        assert!(as_rustls_certificates(&yaml, None).is_err());
+
+        // empty certificate
+        let temp_dir = TempDir::new("rustls_cert_err");
+        let test_dir_path = temp_dir.path();
+        let cert_path = test_dir_path.join("test_cert.pem");
+        fs::write(&cert_path, "").unwrap();
+        let yaml = YamlLoader::load_from_str(&format!("|-\n  {}", cert_path.display())).unwrap();
+        assert!(as_rustls_certificates(&yaml[0], Some(temp_dir.path())).is_err());
+
+        // non-string element in array
+        let yaml = Yaml::Array(vec![Yaml::Integer(123)]);
+        assert!(as_rustls_certificates(&yaml, None).is_err());
+    }
+
+    #[test]
+    fn as_rustls_private_key_ok() {
+        let temp_dir = TempDir::new("rustls_key_ok");
+        let test_dir_path = temp_dir.path();
+        let key_path = test_dir_path.join("test_key.pem");
+        fs::write(&key_path, TEST_KEY_PEM).unwrap();
+
+        // single PEM string
+        let yaml = Yaml::String(TEST_KEY_PEM.to_string());
+        let key = as_rustls_private_key(&yaml, None).unwrap();
+        assert!(matches!(key, PrivateKeyDer::Pkcs8(_)));
+
+        // file path
+        let yaml = YamlLoader::load_from_str(&format!("|-\n  {}", key_path.display())).unwrap();
+        let key = as_rustls_private_key(&yaml[0], Some(temp_dir.path())).unwrap();
+        assert!(matches!(key, PrivateKeyDer::Pkcs8(_)));
+    }
+
+    #[test]
+    fn as_rustls_private_key_err() {
+        // invalid PEM string
+        let yaml = yaml_str!("invalid key");
+        assert!(as_rustls_private_key(&yaml, None).is_err());
+
+        // non-existent file
+        let yaml = yaml_str!("non_existent_key.pem");
+        assert!(as_rustls_private_key(&yaml, Some(Path::new("/non_existent"))).is_err());
+
+        // empty string
+        let yaml = yaml_str!("");
+        assert!(as_rustls_private_key(&yaml, None).is_err());
+
+        // null value
+        let yaml = Yaml::Null;
+        assert!(as_rustls_private_key(&yaml, None).is_err());
+    }
+
+    #[test]
+    fn as_rustls_certificate_pair_ok() {
+        let temp_dir = TempDir::new("rustls_cert_pair_ok");
+        let test_dir_path = temp_dir.path();
+        let cert_path = test_dir_path.join("test_cert.pem");
+        fs::write(&cert_path, TEST_CERT_PEM).unwrap();
+        let key_path = test_dir_path.join("test_key.pem");
+        fs::write(&key_path, TEST_KEY_PEM).unwrap();
+
+        let yaml = YamlLoader::load_from_str(&format!(
+            r#"
+                certificate: |-
+                    {}
+                private_key: |-
+                    {}
+            "#,
+            cert_path.display(),
+            key_path.display()
+        ))
+        .unwrap();
+        let pair = as_rustls_certificate_pair(&yaml[0], None).unwrap();
+        let mut expected = RustlsCertificatePairBuilder::default();
+        expected.set_certs(vec![
+            CertificateDer::from_pem_slice(TEST_CERT_PEM.as_bytes()).unwrap(),
+        ]);
+        expected.set_key(PrivateKeyDer::from_pem_slice(TEST_KEY_PEM.as_bytes()).unwrap());
+        assert_eq!(pair, expected.build().unwrap());
+    }
+
+    #[test]
+    fn as_rustls_certificate_pair_err() {
+        // non-map YAML
+        let yaml = Yaml::Integer(123);
+        assert!(as_rustls_certificate_pair(&yaml, None).is_err());
+
+        let yaml = yaml_str!("invalid");
+        assert!(as_rustls_certificate_pair(&yaml, None).is_err());
+
+        // empty map
+        let yaml = yaml_doc!(r#"{}"#);
+        assert!(as_rustls_certificate_pair(&yaml, None).is_err());
+
+        // invalid certificate
+        let yaml = yaml_doc!(
+            r#"
+                certificate: "invalid cert"
+            "#
+        );
+        assert!(as_rustls_certificate_pair(&yaml[0], None).is_err());
+
+        // invalid private key
+        let yaml = yaml_doc!(
+            r#"
+                private_key: "invalid key"
+            "#
+        );
+        assert!(as_rustls_certificate_pair(&yaml[0], None).is_err());
+
+        // unknown key
+        let yaml = yaml_doc!(
+            r#"
+                unknown_key: "value"
+            "#
+        );
+        assert!(as_rustls_certificate_pair(&yaml[0], None).is_err());
+    }
+
+    #[test]
+    fn as_rustls_client_config_builder_ok() {
+        let temp_dir = TempDir::new("rustls_client_config_builder_ok");
+        let test_dir_path = temp_dir.path();
+        let cert_path = test_dir_path.join("test_cert.pem");
+        fs::write(&cert_path, TEST_CERT_PEM).unwrap();
+        let key_path = test_dir_path.join("test_key.pem");
+        fs::write(&key_path, TEST_KEY_PEM).unwrap();
+        let yaml = YamlLoader::load_from_str(&format!(
+            r#"
+                cert: |-
+                    {}
+                key: |-
+                    {}
+            "#,
+            cert_path.display(),
+            key_path.display()
+        ))
+        .unwrap();
+        let cert_pair1 = as_rustls_certificate_pair(&yaml[0], Some(test_dir_path)).unwrap();
+        let cert_pair2 = as_rustls_certificate_pair(&yaml[0], Some(test_dir_path)).unwrap();
+
+        let yaml = YamlLoader::load_from_str(&format!(
+            r#"
+                no_session_cache: true
+                disable_sni: true
+                max_fragment_size: 1400
+                certificate: |-
+                    {}
+                private_key: |-
+                    {}
+                ca_certificate: |-
+                    {}
+                no_default_ca_certificate: true
+                use_builtin_ca_certificate: true
+                handshake_timeout: "10s"
+            "#,
+            cert_path.display(),
+            key_path.display(),
+            cert_path.display()
+        ))
+        .unwrap();
+        let builder = as_rustls_client_config_builder(&yaml[0], None).unwrap();
+        let mut expected = RustlsClientConfigBuilder::default();
+        expected.set_no_session_cache();
+        expected.set_disable_sni();
+        expected.set_max_fragment_size(1400);
+        expected.set_cert_pair(cert_pair1);
+        let ca_cert = CertificateDer::from_pem_slice(TEST_CERT_PEM.as_bytes()).unwrap();
+        expected.set_ca_certificates(vec![ca_cert]);
+        expected.set_no_default_ca_certificates();
+        expected.set_use_builtin_ca_certificates();
+        expected.set_negotiation_timeout(Duration::from_secs(10));
+        assert_eq!(builder, expected);
+
+        // cert_pair field
+        let yaml = YamlLoader::load_from_str(&format!(
+            r#"
+                cert_pair:
+                    certificate: |-
+                        {}
+                    private_key: |-
+                        {}
+            "#,
+            cert_path.display(),
+            key_path.display()
+        ))
+        .unwrap();
+        let builder = as_rustls_client_config_builder(&yaml[0], None).unwrap();
+        let mut expected = RustlsClientConfigBuilder::default();
+        expected.set_cert_pair(cert_pair2);
+        assert_eq!(builder, expected);
+    }
+
+    #[test]
+    fn as_rustls_client_config_builder_err() {
+        // non-map YAML
+        let yaml = Yaml::Integer(123);
+        assert!(as_rustls_client_config_builder(&yaml, None).is_err());
+
+        let yaml = yaml_str!("invalid");
+        assert!(as_rustls_client_config_builder(&yaml, None).is_err());
+
+        // invalid boolean value
+        let yaml = yaml_doc!(r#"no_session_cache: "not_a_bool""#);
+        assert!(as_rustls_client_config_builder(&yaml[0], None).is_err());
+
+        // invalid max_fragment_size
+        let yaml = yaml_doc!(r#"max_fragment_size: "invalid""#);
+        assert!(as_rustls_client_config_builder(&yaml[0], None).is_err());
+
+        // duplicate certificate config
+        let temp_dir = TempDir::new("rustls_client_config_builder_err");
+        let test_dir_path = temp_dir.path();
+        let cert_path = test_dir_path.join("test_cert.pem");
+        fs::write(&cert_path, TEST_CERT_PEM).unwrap();
+        let key_path = test_dir_path.join("test_key.pem");
+        fs::write(&key_path, TEST_KEY_PEM).unwrap();
+        let yaml = YamlLoader::load_from_str(&format!(
+            r#"
+                cert: |-
+                    {}
+                key: |-
+                    {}
+                cert_pair:
+                    certificate: |-
+                        {}
+                    private_key: |-
+                        {}
+            "#,
+            cert_path.display(),
+            key_path.display(),
+            cert_path.display(),
+            key_path.display()
+        ))
+        .unwrap();
+        assert!(as_rustls_client_config_builder(&yaml[0], None).is_err());
+
+        // unknown key
+        let yaml = yaml_doc!(
+            r#"
+                unknown_key: "value"
+            "#
+        );
+        assert!(as_rustls_client_config_builder(&yaml[0], None).is_err());
+    }
+
+    #[test]
+    fn as_rustls_server_config_builder_ok() {
+        let temp_dir = TempDir::new("rustls_server_config_builder_ok");
+        let test_dir_path = temp_dir.path();
+        let cert_path = test_dir_path.join("test_cert.pem");
+        fs::write(&cert_path, TEST_CERT_PEM).unwrap();
+        let key_path = test_dir_path.join("test_key.pem");
+        fs::write(&key_path, TEST_KEY_PEM).unwrap();
+        let yaml = YamlLoader::load_from_str(&format!(
+            r#"
+                cert: |-
+                    {}
+                key: |-
+                    {}
+            "#,
+            cert_path.display(),
+            key_path.display()
+        ))
+        .unwrap();
+        let cert_pair1 = as_rustls_certificate_pair(&yaml[0], Some(test_dir_path)).unwrap();
+        let cert_pair2 = as_rustls_certificate_pair(&yaml[0], Some(test_dir_path)).unwrap();
+        let cert_pair3 = as_rustls_certificate_pair(&yaml[0], Some(test_dir_path)).unwrap();
+
+        let yaml = YamlLoader::load_from_str(&format!(
+            r#"
+                cert_pairs:
+                  - certificate: |-
+                        {}
+                    private_key: |-
+                        {}
+                enable_client_auth: true
+                use_session_ticket: false
+                no_session_cache: true
+                ca_certificate: |-
+                    {}
+                handshake_timeout: "10s"
+            "#,
+            cert_path.display(),
+            key_path.display(),
+            cert_path.display()
+        ))
+        .unwrap();
+        let builder = as_rustls_server_config_builder(&yaml[0], None).unwrap();
+        let mut expected = RustlsServerConfigBuilder::empty();
+        expected.push_cert_pair(cert_pair1);
+        expected.enable_client_auth();
+        expected.set_use_session_ticket(false);
+        expected.set_disable_session_cache(true);
+        let ca_cert = CertificateDer::from_pem_slice(TEST_CERT_PEM.as_bytes()).unwrap();
+        expected.set_client_auth_certificates(vec![ca_cert]);
+        expected.set_accept_timeout(Duration::from_secs(10));
+        assert_eq!(builder, expected);
+
+        // cert_pair without array
+        let yaml = YamlLoader::load_from_str(&format!(
+            r#"
+                cert_pairs:
+                    certificate: |-
+                        {}
+                    private_key: |-
+                        {}
+                no_session_ticket: true
+            "#,
+            cert_path.display(),
+            key_path.display()
+        ))
+        .unwrap();
+        let builder = as_rustls_server_config_builder(&yaml[0], None).unwrap();
+        let mut expected = RustlsServerConfigBuilder::empty();
+        expected.push_cert_pair(cert_pair2);
+        expected.set_disable_session_ticket(true);
+        assert_eq!(builder, expected);
+
+        // certificate and private_key fields
+        let yaml = YamlLoader::load_from_str(&format!(
+            r#"
+                certificate: |-
+                    {}
+                private_key: |-
+                    {}
+            "#,
+            cert_path.display(),
+            key_path.display()
+        ))
+        .unwrap();
+        let builder = as_rustls_server_config_builder(&yaml[0], None).unwrap();
+        let mut expected = RustlsServerConfigBuilder::empty();
+        expected.push_cert_pair(cert_pair3);
+        assert_eq!(builder, expected);
+    }
+
+    #[test]
+    fn as_rustls_server_config_builder_err() {
+        // non-map YAML
+        let yaml = Yaml::Integer(123);
+        assert!(as_rustls_server_config_builder(&yaml, None).is_err());
+
+        let yaml = yaml_str!("invalid");
+        assert!(as_rustls_server_config_builder(&yaml, None).is_err());
+
+        // empty config (no cert_pairs)
+        let yaml = yaml_doc!(r#"enable_client_auth: true"#);
+        assert!(as_rustls_server_config_builder(&yaml, None).is_err());
+
+        // invalid cert_pairs array element
+        let yaml = yaml_doc!(
+            r#"
+                cert_pairs:
+                  - invalid
+            "#
+        );
+        assert!(as_rustls_server_config_builder(&yaml[0], None).is_err());
+
+        // invalid boolean value
+        let yaml = yaml_doc!(
+            r#"
+                no_session_cache: "not_a_bool"
+            "#
+        );
+        assert!(as_rustls_server_config_builder(&yaml[0], None).is_err());
+
+        // unknown key
+        let yaml = yaml_doc!(
+            r#"
+                unknown_key: "value"
+            "#
+        );
+        assert!(as_rustls_server_config_builder(&yaml[0], None).is_err());
+    }
+}

--- a/lib/g3-yaml/src/value/sched.rs
+++ b/lib/g3-yaml/src/value/sched.rs
@@ -37,3 +37,62 @@ pub fn as_cpu_set(v: &Yaml) -> anyhow::Result<CpuAffinity> {
 
     Ok(set)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use yaml_rust::YamlLoader;
+
+    #[test]
+    fn as_cpu_set_ok() {
+        // valid array of CPU IDs
+        let yaml = yaml_doc!(
+            r#"
+                - 0
+                - 1
+                - 2
+            "#
+        );
+        assert_eq!(as_cpu_set(&yaml).unwrap().cpu_id_list(), &[0, 1, 2]);
+
+        // valid single CPU ID
+        let yaml = yaml_str!("3");
+        assert_eq!(as_cpu_set(&yaml).unwrap().cpu_id_list(), &[3]);
+
+        let yaml = Yaml::Integer(5);
+        assert_eq!(as_cpu_set(&yaml).unwrap().cpu_id_list(), &[5]);
+
+        // valid range of CPU IDs
+        let yaml = yaml_doc!(
+            r#"
+                - 0-2
+                - 4
+            "#
+        );
+        assert_eq!(as_cpu_set(&yaml).unwrap().cpu_id_list(), &[0, 1, 2, 4]);
+    }
+
+    #[test]
+    fn as_cpu_set_err() {
+        // invalid string value
+        let yaml = yaml_str!("abc");
+        assert!(as_cpu_set(&yaml).is_err());
+
+        // invalid integer value
+        let yaml = Yaml::Integer(-1);
+        assert!(as_cpu_set(&yaml).is_err());
+
+        // invalid array value
+        let yaml = yaml_doc!(
+            r#"
+                - 0
+                - abc
+            "#
+        );
+        assert!(as_cpu_set(&yaml).is_err());
+
+        // invalid type
+        let yaml = Yaml::Boolean(true);
+        assert!(as_cpu_set(&yaml).is_err());
+    }
+}


### PR DESCRIPTION
Add unit tests for YAML parsing logic in value modules:
- histogram: tests for quantile parsing and histogram config validation
- rustls: tests for certificate, private key, and certificate pair parsing
- regex: tests for regex pattern validation
- resolve: tests for domain name resolution config
- sched: tests for affinity config parsing
- quinn: tests for QUIC endpoint config validation

## CI Process
<img width="1683" height="761" alt="截图 2025-07-14 00-06-22" src="https://github.com/user-attachments/assets/a5b0599d-6a2f-4806-abb3-c53207d47819" />

## Codecov Data
<img width="2557" height="1081" alt="截图 2025-07-13 23-28-01" src="https://github.com/user-attachments/assets/1172a3f3-a024-410c-a87c-2b455c734a2c" />
