### PR TITLE
g3proxy: allow to drop default port in Host header in http_proxy server

### DIFF
--- a/g3proxy/CHANGELOG
+++ b/g3proxy/CHANGELOG
@@ -1,4 +1,7 @@
 
+v1.11.10:
+ - Feature: allow to drop the default port part in Host header in http_proxy server
+
 v1.11.9:
  - Feature: allow to set hop_limit and traffic_class ipv6 socket options
  - Feature: allow to set congestion control algorithm for TCP socket

--- a/g3proxy/src/config/server/http_proxy.rs
+++ b/g3proxy/src/config/server/http_proxy.rs
@@ -88,6 +88,7 @@ pub(crate) struct HttpProxyServerConfig {
     pub(crate) pipeline_read_idle_timeout: Duration,
     pub(crate) no_early_error_reply: bool,
     pub(crate) allow_custom_host: bool,
+    pub(crate) drop_default_port_in_host: bool,
     pub(crate) body_line_max_len: usize,
     pub(crate) http_forward_upstream_keepalive: HttpKeepAliveConfig,
     pub(crate) http_forward_mark_upstream: bool,
@@ -135,6 +136,7 @@ impl HttpProxyServerConfig {
             pipeline_read_idle_timeout: Duration::from_secs(300),
             no_early_error_reply: false,
             allow_custom_host: true,
+            drop_default_port_in_host: false,
             body_line_max_len: 8192,
             http_forward_upstream_keepalive: Default::default(),
             http_forward_mark_upstream: false,
@@ -358,6 +360,11 @@ impl HttpProxyServerConfig {
             }
             "allow_custom_host" => {
                 self.allow_custom_host = g3_yaml::value::as_bool(v)
+                    .context(format!("invalid bool value for key {k}"))?;
+                Ok(())
+            }
+            "drop_default_port_in_host" => {
+                self.drop_default_port_in_host = g3_yaml::value::as_bool(v)
                     .context(format!("invalid bool value for key {k}"))?;
                 Ok(())
             }

--- a/g3proxy/src/serve/http_proxy/task/pipeline/writer.rs
+++ b/g3proxy/src/serve/http_proxy/task/pipeline/writer.rs
@@ -469,8 +469,18 @@ where
         remote_protocol: HttpProxySubProtocol,
     ) -> LoopAction {
         let is_https = match remote_protocol {
-            HttpProxySubProtocol::HttpForward => false,
-            HttpProxySubProtocol::HttpsForward => true,
+            HttpProxySubProtocol::HttpForward => {
+                if self.ctx.server_config.drop_default_port_in_host && req.upstream.port() == 80 {
+                    req.drop_default_port_in_host();
+                }
+                false
+            }
+            HttpProxySubProtocol::HttpsForward => {
+                if self.ctx.server_config.drop_default_port_in_host && req.upstream.port() == 443 {
+                    req.drop_default_port_in_host();
+                }
+                true
+            }
             _ => unreachable!(),
         };
 

--- a/g3proxy/src/serve/http_proxy/task/protocol/request.rs
+++ b/g3proxy/src/serve/http_proxy/task/protocol/request.rs
@@ -3,7 +3,7 @@
  * Copyright 2023-2025 ByteDance and/or its affiliates.
  */
 
-use http::{Method, Version};
+use http::{HeaderValue, Method, Version, header};
 use tokio::io::AsyncRead;
 use tokio::sync::mpsc;
 use tokio::time::Instant;
@@ -131,5 +131,15 @@ where
 
         // reader should be sent by default
         Ok((req, true))
+    }
+
+    pub(crate) fn drop_default_port_in_host(&mut self) {
+        if let Some(v) = self.inner.end_to_end_headers.get_mut(header::HOST) {
+            let b = v.inner().as_bytes();
+            if let Some(d) = memchr::memchr(b':', b) {
+                let new_v = HeaderValue::from_bytes(&b[..d]).unwrap();
+                v.set_inner(new_v);
+            }
+        }
     }
 }

--- a/lib/g3-types/src/net/http/header/map.rs
+++ b/lib/g3-types/src/net/http/header/map.rs
@@ -45,6 +45,11 @@ impl HttpHeaderMap {
     }
 
     #[inline]
+    pub fn get_mut<K: AsHeaderName>(&mut self, name: K) -> Option<&mut HttpHeaderValue> {
+        self.inner.get_mut(name)
+    }
+
+    #[inline]
     pub fn get_all<K: AsHeaderName>(&self, name: K) -> GetAll<'_, HttpHeaderValue> {
         self.inner.get_all(name)
     }

--- a/lib/g3-types/src/net/http/header/value.rs
+++ b/lib/g3-types/src/net/http/header/value.rs
@@ -55,6 +55,10 @@ impl HttpHeaderValue {
         self.inner = HeaderValue::from_static(value);
     }
 
+    pub fn set_inner(&mut self, inner: HeaderValue) {
+        self.inner = inner;
+    }
+
     #[inline]
     pub fn inner(&self) -> &HeaderValue {
         &self.inner

--- a/sphinx/g3proxy/conf.py
+++ b/sphinx/g3proxy/conf.py
@@ -9,7 +9,7 @@
 project = 'g3proxy'
 copyright = '2020-%Y, Zhang Jingqiang'
 author = 'Zhang Jingqiang'
-release = '1.11.9'
+release = '1.11.10'
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration

--- a/sphinx/g3proxy/configuration/servers/http_proxy.rst
+++ b/sphinx/g3proxy/configuration/servers/http_proxy.rst
@@ -207,6 +207,22 @@ or ip address with the one in the request method line.
 
 .. note:: we don't require the *Host* header to be present in http headers no matter what have been set for this
 
+drop_default_port_in_host
+-------------------------
+
+**optional**, **type**: bool
+
+Set if the default port in Host header should be dropped before sent to upstream.
+
+The default ports are:
+
+  - HTTP 80
+  - HTTPS 443
+
+**default**: false
+
+.. versionadded:: 1.11.10
+
 body_line_max_length
 --------------------
 


### PR DESCRIPTION
close https://github.com/bytedance/g3/issues/720