### PR TITLE
g3-icap-client: replace stale pool connections up-to min_idle count

### DIFF
--- a/lib/g3-icap-client/src/service/client.rs
+++ b/lib/g3-icap-client/src/service/client.rs
@@ -73,9 +73,12 @@ impl IcapServiceClient {
 
     pub fn save_connection(&self, conn: IcapClientConnection) {
         if conn.reusable() {
-            let _ = self
-                .cmd_sender
-                .try_send(IcapServiceClientCommand::SaveConnection(conn));
+            let pool_sender = self.cmd_sender.clone();
+            tokio::spawn(async move {
+                let _ = pool_sender
+                    .send_async(IcapServiceClientCommand::SaveConnection(conn))
+                    .await;
+            });
         }
     }
 }


### PR DESCRIPTION
1. Avoid closing re-usable connections in icap client below max_idle count. 
2. Suggestion to limit replacing stale connections to min_idle in the icap connection pool in order to allow pool idle count to shrink back down in size. 