### PR TITLE
g3-json: add unit tests for JSON value parsers

### DIFF
--- a/lib/g3-json/src/value/auth.rs
+++ b/lib/g3-json/src/value/auth.rs
@@ -23,3 +23,65 @@ pub fn as_password(value: &Value) -> anyhow::Result<Password> {
         Err(anyhow!("json value type for password should be string"))
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn as_username_ok() {
+        // valid username
+        let value = json!("valid_user");
+        let username = as_username(&value).unwrap();
+        assert_eq!(username.as_original(), "valid_user");
+
+        // max length username (255 chars)
+        let max_user = "a".repeat(255);
+        let value = json!(max_user);
+        let username = as_username(&value).unwrap();
+        assert_eq!(username.len() as usize, 255);
+    }
+
+    #[test]
+    fn as_username_err() {
+        // non-string type
+        let value = json!(123);
+        assert!(as_username(&value).is_err());
+
+        // username with colon
+        let value = json!("invalid:user");
+        assert!(as_username(&value).is_err());
+
+        // username too long
+        let long_user = "a".repeat(256);
+        let value = json!(long_user);
+        assert!(as_username(&value).is_err());
+    }
+
+    #[test]
+    fn as_password_ok() {
+        // valid password
+        let value = json!("secure_password");
+        let password = as_password(&value).unwrap();
+        assert_eq!(password.as_original(), "secure_password");
+
+        // max length password (255 chars)
+        let max_pass = "b".repeat(255);
+        let value = json!(max_pass);
+        let password = as_password(&value).unwrap();
+        assert_eq!(password.len() as usize, 255);
+    }
+
+    #[test]
+    fn as_password_err() {
+        // non-string type
+        let value = json!(true);
+        assert!(as_password(&value).is_err());
+
+        // password too long
+        let long_pass = "c".repeat(256);
+        let value = json!(long_pass);
+        assert!(as_password(&value).is_err());
+    }
+}

--- a/lib/g3-json/src/value/metrics.rs
+++ b/lib/g3-json/src/value/metrics.rs
@@ -50,3 +50,131 @@ pub fn as_weighted_metric_node_name(value: &Value) -> anyhow::Result<WeightedVal
         Ok(WeightedValue::new(name))
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn as_metric_node_name_ok() {
+        // Valid node names
+        let v = json!("valid-node1");
+        assert_eq!(as_metric_node_name(&v).unwrap().as_str(), "valid-node1");
+
+        let v = json!("node_with_underscore");
+        assert_eq!(
+            as_metric_node_name(&v).unwrap().as_str(),
+            "node_with_underscore"
+        );
+
+        let v = json!("node123");
+        assert_eq!(as_metric_node_name(&v).unwrap().as_str(), "node123");
+    }
+
+    #[test]
+    fn as_metric_node_name_err() {
+        // Empty string
+        let v = json!("");
+        assert!(as_metric_node_name(&v).is_err());
+
+        // Invalid characters
+        let v = json!("node@name");
+        assert!(as_metric_node_name(&v).is_err());
+
+        let v = json!("node#name");
+        assert!(as_metric_node_name(&v).is_err());
+
+        // Non-string types
+        let v = json!(123);
+        assert!(as_metric_node_name(&v).is_err());
+
+        let v = json!(true);
+        assert!(as_metric_node_name(&v).is_err());
+
+        let v = json!({"name": "test"});
+        assert!(as_metric_node_name(&v).is_err());
+    }
+
+    #[test]
+    fn as_weighted_metric_node_name_ok() {
+        // String input
+        let v = json!("node1");
+        let weighted = as_weighted_metric_node_name(&v).unwrap();
+        assert_eq!(weighted.inner().as_str(), "node1");
+        assert_eq!(weighted.weight(), 1.0);
+
+        // Object with name and weight
+        let v = json!({
+            "name": "node2",
+            "weight": 2.5
+        });
+        let weighted = as_weighted_metric_node_name(&v).unwrap();
+        assert_eq!(weighted.inner().as_str(), "node2");
+        assert_eq!(weighted.weight(), 2.5);
+
+        // Object with only name
+        let v = json!({
+            "name": "node3"
+        });
+        let weighted = as_weighted_metric_node_name(&v).unwrap();
+        assert_eq!(weighted.inner().as_str(), "node3");
+        assert_eq!(weighted.weight(), 1.0);
+
+        // Additional fields should be ignored
+        let v = json!({
+            "name": "node4",
+            "weight": 1.5,
+            "extra": "field"
+        });
+        let weighted = as_weighted_metric_node_name(&v).unwrap();
+        assert_eq!(weighted.inner().as_str(), "node4");
+        assert_eq!(weighted.weight(), 1.5);
+    }
+
+    #[test]
+    fn as_weighted_metric_node_name_err() {
+        // Empty string
+        let v = json!("");
+        assert!(as_weighted_metric_node_name(&v).is_err());
+
+        // Invalid string
+        let v = json!("node@name");
+        assert!(as_weighted_metric_node_name(&v).is_err());
+
+        // Object missing name
+        let v = json!({
+            "weight": 2.0
+        });
+        assert!(as_weighted_metric_node_name(&v).is_err());
+
+        // Object with empty name
+        let v = json!({
+            "name": ""
+        });
+        assert!(as_weighted_metric_node_name(&v).is_err());
+
+        // Object with invalid name
+        let v = json!({
+            "name": "node$name"
+        });
+        assert!(as_weighted_metric_node_name(&v).is_err());
+
+        // Object with invalid weight type
+        let v = json!({
+            "name": "node5",
+            "weight": "invalid"
+        });
+        assert!(as_weighted_metric_node_name(&v).is_err());
+
+        // Invalid types
+        let v = json!(123);
+        assert!(as_weighted_metric_node_name(&v).is_err());
+
+        let v = json!(true);
+        assert!(as_weighted_metric_node_name(&v).is_err());
+
+        let v = json!([1, 2, 3]);
+        assert!(as_weighted_metric_node_name(&v).is_err());
+    }
+}

--- a/lib/g3-json/src/value/primary.rs
+++ b/lib/g3-json/src/value/primary.rs
@@ -225,23 +225,358 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use serde_json::Number;
+    use serde_json::{Number, json};
 
     #[test]
-    fn t_string() {
-        let v = Value::String("123.0".to_string());
-        let pv = as_string(&v).unwrap();
-        assert_eq!(pv, "123.0");
+    fn as_u8_ok() {
+        // valid string input
+        let v = Value::String("123".to_string());
+        assert_eq!(as_u8(&v).unwrap(), 123);
 
+        // valid number input
         let v = Value::Number(Number::from(123u32));
-        let pv = as_string(&v).unwrap();
-        assert_eq!(pv, "123");
+        assert_eq!(as_u8(&v).unwrap(), 123);
+    }
 
+    #[test]
+    fn as_u8_err() {
+        // out of range
+        let v = Value::Number(Number::from(300u32));
+        assert!(as_u8(&v).is_err());
+
+        // negative
+        let v = Value::Number(Number::from(-1i32));
+        assert!(as_u8(&v).is_err());
+
+        // invalid string
+        let v = Value::String("abc".to_string());
+        assert!(as_u8(&v).is_err());
+
+        // invalid type
+        let v = Value::Bool(true);
+        assert!(as_u8(&v).is_err());
+    }
+
+    #[test]
+    fn as_u16_ok() {
+        // valid string input
+        let v = Value::String("12345".to_string());
+        assert_eq!(as_u16(&v).unwrap(), 12345);
+
+        // valid number input
+        let v = Value::Number(Number::from(12345u32));
+        assert_eq!(as_u16(&v).unwrap(), 12345);
+    }
+
+    #[test]
+    fn as_u16_err() {
+        // out of range
+        let v = Value::Number(Number::from(65536u32));
+        assert!(as_u16(&v).is_err());
+
+        // negative
+        let v = Value::Number(Number::from(-1i32));
+        assert!(as_u16(&v).is_err());
+
+        // invalid string
+        let v = Value::String("abc".to_string());
+        assert!(as_u16(&v).is_err());
+
+        // invalid type
+        let v = Value::Bool(true);
+        assert!(as_u16(&v).is_err());
+    }
+
+    #[test]
+    fn as_i32_ok() {
+        // valid string input
+        let v = Value::String("-123".to_string());
+        assert_eq!(as_i32(&v).unwrap(), -123);
+
+        // valid number input
         let v = Value::Number(Number::from(-123i32));
-        let pv = as_string(&v).unwrap();
-        assert_eq!(pv, "-123");
+        assert_eq!(as_i32(&v).unwrap(), -123);
+    }
 
-        let v = Value::Number(Number::from_f64(123.0).unwrap());
+    #[test]
+    fn as_i32_err() {
+        // out of range
+        let v = Value::Number(Number::from(2147483648u64));
+        assert!(as_i32(&v).is_err());
+
+        // invalid string
+        let v = Value::String("abc".to_string());
+        assert!(as_i32(&v).is_err());
+
+        // invalid type
+        let v = Value::Bool(true);
+        assert!(as_i32(&v).is_err());
+    }
+
+    #[test]
+    fn as_u32_ok() {
+        // valid string input
+        let v = Value::String("123456".to_string());
+        assert_eq!(as_u32(&v).unwrap(), 123456);
+
+        // valid number input
+        let v = Value::Number(Number::from(123456u32));
+        assert_eq!(as_u32(&v).unwrap(), 123456);
+    }
+
+    #[test]
+    fn as_u32_err() {
+        // out of range
+        let v = Value::Number(Number::from(4294967296u64));
+        assert!(as_u32(&v).is_err());
+
+        // negative NonZeroU32
+        let v = Value::Number(Number::from(-123i32));
+        assert!(as_u32(&v).is_err());
+
+        // invalid string
+        let v = Value::String("abc".to_string());
+        assert!(as_u32(&v).is_err());
+
+        // invalid type
+        let v = Value::Bool(true);
+        assert!(as_u32(&v).is_err());
+    }
+
+    #[test]
+    fn as_nonzero_u32_ok() {
+        // valid string input
+        let v = Value::String("123".to_string());
+        assert_eq!(as_nonzero_u32(&v).unwrap(), NonZeroU32::new(123).unwrap());
+
+        // valid number input
+        let v = Value::Number(Number::from(123u32));
+        assert_eq!(as_nonzero_u32(&v).unwrap(), NonZeroU32::new(123).unwrap());
+    }
+
+    #[test]
+    fn as_nonzero_u32_err() {
+        // zero value
+        let v = Value::String("0".to_string());
+        assert!(as_nonzero_u32(&v).is_err());
+
+        let v = Value::Number(Number::from(0u32));
+        assert!(as_nonzero_u32(&v).is_err());
+
+        // out of range
+        let v = Value::Number(Number::from(4294967296u64));
+        assert!(as_nonzero_u32(&v).is_err());
+
+        // negative number
+        let v = Value::Number(Number::from(-123i32));
+        assert!(as_nonzero_u32(&v).is_err());
+
+        // invalid type
+        let v = Value::Bool(true);
+        assert!(as_nonzero_u32(&v).is_err());
+
+        let v = Value::Null;
+        assert!(as_nonzero_u32(&v).is_err());
+    }
+
+    #[test]
+    fn as_usize_ok() {
+        // valid string input
+        let v = Value::String("123".to_string());
+        assert_eq!(as_usize(&v).unwrap(), 123);
+
+        // valid number input
+        let v = Value::Number(Number::from(123u32));
+        assert_eq!(as_usize(&v).unwrap(), 123);
+    }
+
+    #[test]
+    fn as_usize_err() {
+        // negative number
+        let v = Value::Number(Number::from(-123i32));
+        assert!(as_usize(&v).is_err());
+
+        // invalid string
+        let v = Value::String("abc".to_string());
+        assert!(as_usize(&v).is_err());
+
+        // invalid type
+        let v = Value::Bool(true);
+        assert!(as_usize(&v).is_err());
+
+        let v = Value::Null;
+        assert!(as_usize(&v).is_err());
+    }
+
+    #[test]
+    fn as_f64_ok() {
+        // valid string input
+        let v = Value::String("123.45".to_string());
+        assert_eq!(as_f64(&v).unwrap(), 123.45);
+
+        // valid number input
+        let v = Value::Number(Number::from_f64(123.45).unwrap());
+        assert_eq!(as_f64(&v).unwrap(), 123.45);
+    }
+
+    #[test]
+    fn as_f64_err() {
+        // invalid string
+        let v = Value::String("abc".to_string());
+        assert!(as_f64(&v).is_err());
+
+        // invalid type
+        let v = Value::Bool(true);
+        assert!(as_f64(&v).is_err());
+    }
+
+    #[test]
+    fn as_bool_ok() {
+        // string representations
+        assert!(as_bool(&Value::String("on".to_string())).unwrap());
+        assert!(as_bool(&Value::String("true".to_string())).unwrap());
+        assert!(as_bool(&Value::String("1".to_string())).unwrap());
+        assert!(!as_bool(&Value::String("off".to_string())).unwrap());
+        assert!(!as_bool(&Value::String("false".to_string())).unwrap());
+        assert!(!as_bool(&Value::String("0".to_string())).unwrap());
+
+        // boolean values
+        assert!(as_bool(&Value::Bool(true)).unwrap());
+        assert!(!as_bool(&Value::Bool(false)).unwrap());
+
+        // numeric values
+        assert!(as_bool(&Value::Number(Number::from(1))).unwrap());
+        assert!(!as_bool(&Value::Number(Number::from(0))).unwrap());
+        assert!(as_bool(&Value::Number(Number::from(-1))).unwrap());
+    }
+
+    #[test]
+    fn as_bool_err() {
+        // invalid string
+        let v = Value::String("maybe".to_string());
+        assert!(as_bool(&v).is_err());
+
+        // unsupported type
+        let v = Value::Null;
+        assert!(as_bool(&v).is_err());
+    }
+
+    #[test]
+    fn as_bytes_ok() {
+        let mut buffer = [0u8; 4];
+        let v = Value::String("deadbeef".to_string());
+        as_bytes(&v, &mut buffer).unwrap();
+        assert_eq!(buffer, [0xde, 0xad, 0xbe, 0xef]);
+    }
+
+    #[test]
+    fn as_bytes_err() {
+        let mut buffer = [0u8; 4];
+
+        // invalid hex
+        let v = Value::String("xxxx".to_string());
+        assert!(as_bytes(&v, &mut buffer).is_err());
+
+        // wrong length
+        let v = Value::String("dead".to_string());
+        assert!(as_bytes(&v, &mut buffer).is_err());
+
+        // invalid type
+        let v = Value::Number(Number::from(123));
+        assert!(as_bytes(&v, &mut buffer).is_err());
+    }
+
+    #[test]
+    fn as_ascii_ok() {
+        let v = Value::String("hello".to_string());
+        assert_eq!(as_ascii(&v).unwrap(), "hello");
+    }
+
+    #[test]
+    fn as_ascii_err() {
+        // non-ASCII string
+        let v = Value::String("你好".to_string());
+        assert!(as_ascii(&v).is_err());
+    }
+
+    #[test]
+    fn as_string_ok() {
+        // string value
+        let v = Value::String("test".to_string());
+        assert_eq!(as_string(&v).unwrap(), "test");
+
+        let v = Value::String("123.0".to_string());
+        assert_eq!(as_string(&v).unwrap(), "123.0");
+
+        // integer conversion
+        let v = Value::Number(Number::from(123u32));
+        assert_eq!(as_string(&v).unwrap(), "123");
+
+        // negative integer
+        let v = Value::Number(Number::from(-123i32));
+        assert_eq!(as_string(&v).unwrap(), "-123");
+    }
+
+    #[test]
+    fn as_string_err() {
+        // float conversion
+        let v = Value::Number(Number::from_f64(123.45).unwrap());
         assert!(as_string(&v).is_err());
+
+        // invalid type
+        let v = Value::Bool(true);
+        assert!(as_string(&v).is_err());
+    }
+
+    #[test]
+    fn as_list_ok() {
+        // array input
+        let v = Value::Array(vec![
+            Value::Number(Number::from(1)),
+            Value::Number(Number::from(2)),
+            Value::Number(Number::from(3)),
+        ]);
+        assert_eq!(as_list(&v, as_u8).unwrap(), vec![1, 2, 3]);
+
+        // single value input
+        let v = Value::Number(Number::from(42));
+        assert_eq!(as_list(&v, as_u8).unwrap(), vec![42]);
+    }
+
+    #[test]
+    fn as_list_err() {
+        // element conversion failure
+        let v = Value::Array(vec![
+            Value::Number(Number::from(1)),
+            Value::String("invalid".to_string()),
+        ]);
+        assert!(as_list(&v, as_u8).is_err());
+    }
+
+    #[test]
+    fn as_hashmap_ok() {
+        let v = json!({
+            "key1": 1,
+            "key2": 2
+        });
+
+        let result: HashMap<String, u8> = as_hashmap(&v, |k| Ok(k.to_string()), as_u8).unwrap();
+
+        assert_eq!(result.get("key1"), Some(&1));
+        assert_eq!(result.get("key2"), Some(&2));
+    }
+
+    #[test]
+    fn as_hashmap_err() {
+        // non-object input
+        let v = Value::Array(vec![]);
+        assert!(as_hashmap(&v, |k| Ok(k.to_string()), as_u8).is_err());
+
+        // key conversion failure
+        let v = json!({
+            "key1": 1,
+            "key2": "invalid"
+        });
+        assert!(as_hashmap(&v, |k| Ok(k.to_string()), as_u8).is_err());
     }
 }

--- a/lib/g3-json/src/value/random.rs
+++ b/lib/g3-json/src/value/random.rs
@@ -43,3 +43,61 @@ pub fn as_random_ratio(value: &Value) -> anyhow::Result<Bernoulli> {
         )),
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn as_random_ratio_ok() {
+        // valid Number values
+        assert_eq!(as_random_ratio(&json!(0.5)).unwrap().p(), 0.5);
+        assert_eq!(as_random_ratio(&json!(1.0)).unwrap().p(), 1.0);
+        assert_eq!(as_random_ratio(&json!(0.0)).unwrap().p(), 0.0);
+
+        // valid fraction format strings
+        assert_eq!(as_random_ratio(&json!("1/2")).unwrap().p(), 0.5);
+        assert_eq!(as_random_ratio(&json!("3/4")).unwrap().p(), 0.75);
+
+        // valid percentage format strings
+        assert_eq!(as_random_ratio(&json!("50%")).unwrap().p(), 0.5);
+        assert_eq!(as_random_ratio(&json!("100%")).unwrap().p(), 1.0);
+
+        // valid float strings
+        assert_eq!(as_random_ratio(&json!("0.7")).unwrap().p(), 0.7);
+        assert_eq!(as_random_ratio(&json!("1.0")).unwrap().p(), 1.0);
+
+        // boolean values
+        assert_eq!(as_random_ratio(&json!(true)).unwrap().p(), 1.0);
+        assert_eq!(as_random_ratio(&json!(false)).unwrap().p(), 0.0);
+    }
+
+    #[test]
+    fn as_random_ratio_err() {
+        // invalid Number values
+        assert!(as_random_ratio(&json!(-0.5)).is_err());
+        assert!(as_random_ratio(&json!(1.5)).is_err());
+        assert!(as_random_ratio(&json!(123)).is_err());
+
+        // invalid fraction format strings
+        assert!(as_random_ratio(&json!("a/2")).is_err());
+        assert!(as_random_ratio(&json!("1/b")).is_err());
+        assert!(as_random_ratio(&json!("3/0")).is_err());
+        assert!(as_random_ratio(&json!("1.5/2")).is_err());
+
+        // invalid percentage format strings
+        assert!(as_random_ratio(&json!("a%")).is_err());
+        assert!(as_random_ratio(&json!("150%")).is_err());
+
+        // invalid float strings
+        assert!(as_random_ratio(&json!("abc")).is_err());
+        assert!(as_random_ratio(&json!("-0.5")).is_err());
+        assert!(as_random_ratio(&json!("2.5")).is_err());
+
+        // unsupported types
+        assert!(as_random_ratio(&json!([])).is_err());
+        assert!(as_random_ratio(&json!({})).is_err());
+        assert!(as_random_ratio(&json!(null)).is_err());
+    }
+}

--- a/lib/g3-json/src/value/speed_limit.rs
+++ b/lib/g3-json/src/value/speed_limit.rs
@@ -164,3 +164,247 @@ pub fn as_global_datagram_speed_limit(v: &Value) -> anyhow::Result<GlobalDatagra
         _ => Err(anyhow!("invalid json value type")),
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn as_tcp_sock_speed_limit_ok() {
+        // String input
+        let value = json!("10MB");
+        let config = as_tcp_sock_speed_limit(&value).unwrap();
+        assert_eq!(config.max_north, 10_000_000);
+        assert_eq!(config.max_south, 10_000_000);
+        assert_eq!(
+            config.shift_millis,
+            g3_types::net::RATE_LIMIT_SHIFT_MILLIS_DEFAULT
+        );
+
+        // Number input
+        let value = json!(102400);
+        let config = as_tcp_sock_speed_limit(&value).unwrap();
+        assert_eq!(config.max_north, 102400);
+        assert_eq!(config.max_south, 102400);
+
+        // Object input
+        let value = json!({
+            "shift": 5,
+            "upload": "5MB",
+            "download": "10MB"
+        });
+        let config = as_tcp_sock_speed_limit(&value).unwrap();
+        assert_eq!(config.shift_millis, 5);
+        assert_eq!(config.max_north, 5_000_000);
+        assert_eq!(config.max_south, 10_000_000);
+
+        // Alternative keys
+        let value = json!({
+            "shift_millis": 10,
+            "north_bytes": "1MB",
+            "south_bytes": "2MB"
+        });
+        let config = as_tcp_sock_speed_limit(&value).unwrap();
+        assert_eq!(config.shift_millis, 10);
+        assert_eq!(config.max_north, 1_000_000);
+        assert_eq!(config.max_south, 2_000_000);
+    }
+
+    #[test]
+    fn as_tcp_sock_speed_limit_err() {
+        // Invalid type (array)
+        let value = json!([]);
+        assert!(as_tcp_sock_speed_limit(&value).is_err());
+
+        // Invalid key
+        let value = json!({"invalid_key": 100});
+        assert!(as_tcp_sock_speed_limit(&value).is_err());
+
+        // Shift value too large
+        let value = json!({
+            "shift": 100,
+            "upload": "1MB"
+        });
+        assert!(as_tcp_sock_speed_limit(&value).is_err());
+
+        // Upload limit zero when shift is set
+        let value = json!({
+            "shift": 5,
+            "upload": 0
+        });
+        assert!(as_tcp_sock_speed_limit(&value).is_err());
+
+        // Invalid value type
+        let value = json!({"shift": "abc"});
+        assert!(as_tcp_sock_speed_limit(&value).is_err());
+    }
+
+    #[test]
+    fn as_udp_sock_speed_limit_ok() {
+        // String input
+        let value = json!("5MB");
+        let config = as_udp_sock_speed_limit(&value).unwrap();
+        assert_eq!(config.max_north_bytes, 5_000_000);
+        assert_eq!(config.max_south_bytes, 5_000_000);
+
+        // Number input
+        let value = json!(51200);
+        let config = as_udp_sock_speed_limit(&value).unwrap();
+        assert_eq!(config.max_north_bytes, 51200);
+        assert_eq!(config.max_south_bytes, 51200);
+
+        // Object input with packets and bytes
+        let value = json!({
+            "shift": 4,
+            "upload_packets": 500,
+            "download_packets": 1000,
+            "upload_bytes": "2MB",
+            "download_bytes": "4MB"
+        });
+        let config = as_udp_sock_speed_limit(&value).unwrap();
+        assert_eq!(config.shift_millis, 4);
+        assert_eq!(config.max_north_packets, 500);
+        assert_eq!(config.max_south_packets, 1000);
+        assert_eq!(config.max_north_bytes, 2_000_000);
+        assert_eq!(config.max_south_bytes, 4_000_000);
+
+        // Alternative keys
+        let value = json!({
+            "shift_millis": 10,
+            "north_packets": 1000,
+            "south_packets": 2000,
+            "north_bytes": "1MB",
+            "south_bytes": "2MB"
+        });
+        let config = as_udp_sock_speed_limit(&value).unwrap();
+        assert_eq!(config.shift_millis, 10);
+        assert_eq!(config.max_north_packets, 1000);
+        assert_eq!(config.max_south_packets, 2000);
+        assert_eq!(config.max_north_bytes, 1_000_000);
+        assert_eq!(config.max_south_bytes, 2_000_000);
+    }
+
+    #[test]
+    fn as_udp_sock_speed_limit_err() {
+        // Invalid type (null)
+        let value = json!(null);
+        assert!(as_udp_sock_speed_limit(&value).is_err());
+
+        // Invalid key
+        let value = json!({"invalid_key": 100});
+        assert!(as_udp_sock_speed_limit(&value).is_err());
+
+        // Shift value too large
+        let value = json!({
+            "shift": 100,
+            "upload_bytes": "1MB"
+        });
+        assert!(as_udp_sock_speed_limit(&value).is_err());
+
+        // Invalid value type
+        let value = json!({"shift": "abc"});
+        assert!(as_udp_sock_speed_limit(&value).is_err());
+    }
+
+    #[test]
+    fn as_global_stream_speed_limit_ok() {
+        // String input
+        let value = json!("1GB");
+        let config = as_global_stream_speed_limit(&value).unwrap();
+        assert_eq!(config.replenish_bytes(), 1_000_000_000);
+        assert_eq!(
+            config.replenish_interval(),
+            std::time::Duration::from_secs(1)
+        );
+
+        // Number input
+        let value = json!(102400000);
+        let config = as_global_stream_speed_limit(&value).unwrap();
+        assert_eq!(config.replenish_bytes(), 102400000);
+
+        // Object input
+        let value = json!({
+            "replenish_interval": "500ms",
+            "replenish_bytes": "1MB",
+            "max_burst_bytes": "2MB"
+        });
+        let config = as_global_stream_speed_limit(&value).unwrap();
+        assert_eq!(
+            config.replenish_interval(),
+            std::time::Duration::from_millis(500)
+        );
+        assert_eq!(config.replenish_bytes(), 1_000_000);
+        assert_eq!(config.max_burst_bytes(), 2_000_000);
+    }
+
+    #[test]
+    fn as_global_stream_speed_limit_err() {
+        // Invalid type (array)
+        let value = json!([]);
+        assert!(as_global_stream_speed_limit(&value).is_err());
+
+        // Missing replenish_bytes
+        let value = json!({"max_burst_bytes": "1GB"});
+        assert!(as_global_stream_speed_limit(&value).is_err());
+
+        // Invalid key
+        let value = json!({"invalid_key": 100});
+        assert!(as_global_stream_speed_limit(&value).is_err());
+
+        // Invalid value type
+        let value = json!({"replenish_interval": "abc"});
+        assert!(as_global_stream_speed_limit(&value).is_err());
+    }
+
+    #[test]
+    fn as_global_datagram_speed_limit_ok() {
+        // String input
+        let value = json!("500KB");
+        let config = as_global_datagram_speed_limit(&value).unwrap();
+        assert_eq!(config.replenish_bytes(), 500_000);
+        assert_eq!(config.replenish_packets(), 0);
+
+        // Number input
+        let value = json!(51200);
+        let config = as_global_datagram_speed_limit(&value).unwrap();
+        assert_eq!(config.replenish_bytes(), 51200);
+
+        // Object input with packets and bytes
+        let value = json!({
+            "replenish_interval": "1s",
+            "replenish_bytes": "500KB",
+            "replenish_packets": 100,
+            "max_burst_bytes": "1MB",
+            "max_burst_packets": 200
+        });
+        let config = as_global_datagram_speed_limit(&value).unwrap();
+        assert_eq!(
+            config.replenish_interval(),
+            std::time::Duration::from_secs(1)
+        );
+        assert_eq!(config.replenish_bytes(), 500_000);
+        assert_eq!(config.replenish_packets(), 100);
+        assert_eq!(config.max_burst_bytes(), 1_000_000);
+        assert_eq!(config.max_burst_packets(), 200);
+    }
+
+    #[test]
+    fn as_global_datagram_speed_limit_err() {
+        // Invalid type (boolean)
+        let value = json!(true);
+        assert!(as_global_datagram_speed_limit(&value).is_err());
+
+        // Missing replenish values
+        let value = json!({"replenish_interval": "1s"});
+        assert!(as_global_datagram_speed_limit(&value).is_err());
+
+        // Invalid key
+        let value = json!({"invalid_key": 100});
+        assert!(as_global_datagram_speed_limit(&value).is_err());
+
+        // Invalid value type
+        let value = json!({"replenish_bytes": "abc"});
+        assert!(as_global_datagram_speed_limit(&value).is_err());
+    }
+}


### PR DESCRIPTION
- Add unit tests for JSON parsing functions across multiple value modules.

## CI Process
<img width="1672" height="759" alt="截图 2025-07-27 21-36-48" src="https://github.com/user-attachments/assets/354b79ae-81a7-4e64-bc5c-21a08983453b" />

## Codecov Data
<img width="2568" height="1180" alt="截图 2025-07-27 21-37-28" src="https://github.com/user-attachments/assets/051f37fd-0f8d-4c6e-b82c-d553416cd8d6" />
