### PR TITLE
add protocol detection tests for multiple services

### DIFF
--- a/lib/g3-dpi/tests/ftp.rs
+++ b/lib/g3-dpi/tests/ftp.rs
@@ -3,17 +3,108 @@
  * Copyright 2023-2025 ByteDance and/or its affiliates.
  */
 
-use g3_dpi::{Protocol, ProtocolInspectionConfig, ProtocolInspector};
+use g3_dpi::{
+    MaybeProtocol, Protocol, ProtocolInspectError, ProtocolInspectionConfig, ProtocolInspector,
+};
 
+// Helper function to check FTP server greeting
+fn check_ftp_greeting(data: &[u8], port: u16) -> Result<Protocol, ProtocolInspectError> {
+    let mut inspector = ProtocolInspector::default();
+    inspector.push_protocol(MaybeProtocol::Ftp);
+    let config = ProtocolInspectionConfig::default();
+    inspector.check_server_initial_data(&config, port, data)
+}
+
+// Tests for valid FTP responses
 #[test]
 fn port21_220_gnu() {
+    const DATA: &[u8] = b"220 GNU FTP server ready.\r\n";
+    let protocol = check_ftp_greeting(DATA, 21).unwrap();
+    assert_eq!(protocol, Protocol::FtpControl);
+}
+
+#[test]
+fn port21_120_service_ready() {
+    const DATA: &[u8] = b"120 Service ready\r\n";
+    let protocol = check_ftp_greeting(DATA, 21).unwrap();
+    assert_eq!(protocol, Protocol::FtpControl);
+}
+
+#[test]
+fn port21_421_too_many_users() {
+    const DATA: &[u8] = b"421 Too many users, try later\r\n";
+    let protocol = check_ftp_greeting(DATA, 21).unwrap();
+    assert_eq!(protocol, Protocol::FtpControl);
+}
+
+// Tests for invalid responses
+#[test]
+fn port21_200_invalid_response() {
+    const DATA: &[u8] = b"200 Invalid response\r\n";
+    let protocol = check_ftp_greeting(DATA, 21).unwrap();
+    assert_eq!(protocol, Protocol::Unknown);
+}
+
+#[test]
+fn port21_220_missing_newline() {
+    const DATA: &[u8] = b"220 Server ready";
+    let result = check_ftp_greeting(DATA, 21);
+    assert!(matches!(result, Err(ProtocolInspectError::NeedMoreData(1))));
+}
+
+#[test]
+fn port21_220_invalid_suffix() {
+    const DATA: &[u8] = b"220XInvalid suffix\r\n";
+    let protocol = check_ftp_greeting(DATA, 21).unwrap();
+    assert_eq!(protocol, Protocol::Unknown);
+}
+
+// Tests for data length boundaries
+#[test]
+fn insufficient_data_less_than_min() {
+    const DATA: &[u8] = b"123";
+    let result = check_ftp_greeting(DATA, 21);
+    assert!(matches!(result, Err(ProtocolInspectError::NeedMoreData(3))));
+}
+
+// Test protocol exclusion through behavior
+#[test]
+fn excludes_other_protocols_after_detection() {
     let mut inspector = ProtocolInspector::default();
     let config = ProtocolInspectionConfig::default();
 
-    const DATA: &[u8] = b"220 GNU FTP server ready.\r\n";
-
+    // First detect FTP
+    const FTP_DATA: &[u8] = b"220 FTP Server\r\n";
     let protocol = inspector
-        .check_server_initial_data(&config, 21, DATA)
+        .check_server_initial_data(&config, 21, FTP_DATA)
         .unwrap();
+    assert_eq!(protocol, Protocol::FtpControl);
+
+    // Now try to detect SSH (should be excluded)
+    const SSH_DATA: &[u8] = b"SSH-2.0-OpenSSH";
+    let protocol = inspector
+        .check_server_initial_data(&config, 22, SSH_DATA)
+        .unwrap();
+    assert_eq!(protocol, Protocol::Unknown);
+}
+
+// Test multi-line response
+#[test]
+fn port21_multi_line_response() {
+    const DATA: &[u8] = b"220-FTP Server\r\n220 Ready\r\n";
+    let protocol = check_ftp_greeting(DATA, 21).unwrap();
+    assert_eq!(protocol, Protocol::FtpControl);
+}
+
+// Test long response handling
+#[test]
+fn long_response_handling() {
+    // Create response that's 600 bytes long
+    let mut data = Vec::from("220 ");
+    data.extend(vec![b'A'; 596]);
+    data.extend(b"\r\n");
+
+    // Should be detected as FTP despite length
+    let protocol = check_ftp_greeting(&data, 21).unwrap();
     assert_eq!(protocol, Protocol::FtpControl);
 }

--- a/lib/g3-dpi/tests/http.rs
+++ b/lib/g3-dpi/tests/http.rs
@@ -3,7 +3,7 @@
  * Copyright 2023-2025 ByteDance and/or its affiliates.
  */
 
-use g3_dpi::{Protocol, ProtocolInspectionConfig, ProtocolInspector};
+use g3_dpi::{Protocol, ProtocolInspectError, ProtocolInspectionConfig, ProtocolInspector};
 
 #[test]
 fn port80_small() {
@@ -17,4 +17,155 @@ fn port80_small() {
         .check_client_initial_data(&config, 80, DATA)
         .unwrap();
     assert_eq!(protocol, Protocol::Http1);
+}
+
+#[test]
+fn http2_connection_preface() {
+    let mut inspector = ProtocolInspector::default();
+    let config = ProtocolInspectionConfig::default();
+
+    const DATA: &[u8] = b"PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n";
+
+    let protocol = inspector
+        .check_client_initial_data(&config, 80, DATA)
+        .unwrap();
+    assert_eq!(protocol, Protocol::Http2);
+}
+
+#[test]
+fn http_methods() {
+    let mut inspector = ProtocolInspector::default();
+    let config = ProtocolInspectionConfig::default();
+
+    let methods = [
+        "GET", "POST", "PUT", "DELETE", "HEAD", "OPTIONS", "CONNECT", "TRACE", "PATCH",
+    ];
+
+    for method in methods {
+        let request = format!("{method} / HTTP/1.1\r\nHost: example.com\r\n\r\n");
+        let protocol = inspector
+            .check_client_initial_data(&config, 80, request.as_bytes())
+            .unwrap();
+        assert_eq!(protocol, Protocol::Http1);
+        inspector.reset_state(); // Reset for next test
+    }
+}
+
+#[test]
+fn insufficient_data() {
+    let mut inspector = ProtocolInspector::default();
+    let config = ProtocolInspectionConfig::default();
+
+    // Minimum data length is 18, provide only 17 bytes
+    const DATA: &[u8] = b"GET / HTTP/1.1\r\nH";
+
+    let result = inspector.check_client_initial_data(&config, 80, DATA);
+    assert!(matches!(result, Err(ProtocolInspectError::NeedMoreData(1))));
+}
+
+#[test]
+fn invalid_http_version() {
+    let mut inspector = ProtocolInspector::default();
+    let config = ProtocolInspectionConfig::default();
+
+    const DATA: &[u8] = b"GET / HTTP/1.2\r\nHost: example.com\r\n\r\n";
+
+    let protocol = inspector
+        .check_client_initial_data(&config, 80, DATA)
+        .unwrap();
+    assert_eq!(protocol, Protocol::Unknown);
+}
+
+#[test]
+fn non_standard_port() {
+    let mut inspector = ProtocolInspector::default();
+    let config = ProtocolInspectionConfig::default();
+
+    const DATA: &[u8] = b"GET / HTTP/1.1\r\nHost: example.com\r\n\r\n";
+
+    // Should detect HTTP even on non-80 port
+    let protocol = inspector
+        .check_client_initial_data(&config, 8080, DATA)
+        .unwrap();
+    assert_eq!(protocol, Protocol::Http1);
+}
+
+#[test]
+fn uri_too_long() {
+    let mut inspector = ProtocolInspector::default();
+    let config = ProtocolInspectionConfig::default();
+
+    const DEFAULT_URI_LIMIT: usize = 4096;
+    let long_uri = "a".repeat(DEFAULT_URI_LIMIT + 10);
+    let request = format!("GET /{long_uri} HTTP/1.1\r\nHost: example.com\r\n\r\n");
+
+    let protocol = inspector
+        .check_client_initial_data(&config, 80, request.as_bytes())
+        .unwrap();
+    assert_eq!(protocol, Protocol::Http1);
+}
+
+#[test]
+fn special_methods() {
+    let mut inspector = ProtocolInspector::default();
+    let config = ProtocolInspectionConfig::default();
+
+    let methods = [
+        "ACL",
+        "BIND",
+        "COPY",
+        "CHECKIN",
+        "CHECKOUT",
+        "LOCK",
+        "LINK",
+        "MOVE",
+        "MKCOL",
+        "MERGE",
+        "MKACTIVITY",
+        "MKREDIRECTREF",
+    ];
+
+    for method in methods {
+        let request = format!("{method} / HTTP/1.1\r\nHost: example.com\r\n\r\n");
+        let protocol = inspector
+            .check_client_initial_data(&config, 80, request.as_bytes())
+            .unwrap();
+        assert_eq!(protocol, Protocol::Http1);
+        inspector.reset_state();
+    }
+}
+
+#[test]
+fn invalid_method_prefix() {
+    let mut inspector = ProtocolInspector::default();
+    let config = ProtocolInspectionConfig::default();
+
+    const DEFAULT_URI_LIMIT: usize = 4096;
+    let long_uri = "a".repeat(DEFAULT_URI_LIMIT + 10);
+    let request = format!("XET /{long_uri} HTTP/1.1\r\nHost: example.com\r\n\r\n");
+
+    let protocol = inspector
+        .check_client_initial_data(&config, 80, request.as_bytes())
+        .unwrap();
+    assert_eq!(protocol, Protocol::Unknown);
+}
+
+#[test]
+fn protocol_exclusion() {
+    let mut inspector = ProtocolInspector::default();
+    let config = ProtocolInspectionConfig::default();
+
+    // First detect HTTP
+    const HTTP_DATA: &[u8] = b"GET / HTTP/1.1\r\nHost: example.com\r\n\r\n";
+    let protocol = inspector
+        .check_client_initial_data(&config, 80, HTTP_DATA)
+        .unwrap();
+    assert_eq!(protocol, Protocol::Http1);
+
+    // Now try SSH (should be excluded)
+    const SSH_DATA: &[u8] = b"SSH-2.0-OpenSSH\r\n\r\n";
+    let protocol = inspector
+        .check_client_initial_data(&config, 22, SSH_DATA)
+        .unwrap();
+    assert_eq!(protocol, Protocol::Unknown);
 }

--- a/lib/g3-dpi/tests/imap.rs
+++ b/lib/g3-dpi/tests/imap.rs
@@ -3,18 +3,214 @@
  * Copyright 2023-2025 ByteDance and/or its affiliates.
  */
 
-use g3_dpi::{Protocol, ProtocolInspectionConfig, ProtocolInspector};
+use g3_dpi::{
+    MaybeProtocol, Protocol, ProtocolInspectError, ProtocolInspectionConfig, ProtocolInspector,
+};
+
+// Helper function to check IMAP server greeting with optional size limit
+fn check_imap_greeting(
+    data: &[u8],
+    size_limit: Option<usize>,
+) -> Result<Protocol, ProtocolInspectError> {
+    let mut inspector = ProtocolInspector::default();
+    let mut config = ProtocolInspectionConfig::default();
+
+    // Apply custom size limit if provided
+    if let Some(limit) = size_limit {
+        config.size_limit_mut().set_imap_server_greeting_msg(limit);
+    }
+
+    // Push IMAP protocol to ensure it's checked first
+    inspector.push_protocol(MaybeProtocol::Imap);
+    inspector.check_server_initial_data(&config, 143, data)
+}
 
 #[test]
 fn port143_outlook() {
-    let mut inspector = ProtocolInspector::default();
-    let config = ProtocolInspectionConfig::default();
-
     const DATA: &[u8] =
         b"* OK The Microsoft Exchange IMAP4 service is ready. [UwBJADIAUABSADAANABDAEEAMAAwADAANQAuAGEAcABjAHAAcgBkADAANAAuAHAAcgBvAGQALgBvAHUAdABsAG8AbwBrAC4AYwBvAG0A]\r\n";
 
+    let protocol = check_imap_greeting(DATA, None).unwrap();
+    assert_eq!(protocol, Protocol::Imap);
+}
+
+// Tests for valid IMAP responses
+#[test]
+fn valid_ok_response() {
+    const DATA: &[u8] = b"* OK Server ready\r\n";
+    let protocol = check_imap_greeting(DATA, None).unwrap();
+    assert_eq!(protocol, Protocol::Imap);
+}
+
+#[test]
+fn valid_preauth_response() {
+    const DATA: &[u8] = b"* PREAUTH [CAPABILITY IMAP4rev1 SASL-IR LOGIN-REFERRALS STARTTLS AUTH=PLAIN] Logged in\r\n";
+    let protocol = check_imap_greeting(DATA, None).unwrap();
+    assert_eq!(protocol, Protocol::Imap);
+}
+
+#[test]
+fn valid_bye_response() {
+    const DATA: &[u8] = b"* BYE Autologout; idle for too long\r\n";
+    let protocol = check_imap_greeting(DATA, None).unwrap();
+    assert_eq!(protocol, Protocol::Imap);
+}
+
+#[test]
+fn valid_multi_line_response() {
+    const DATA: &[u8] = b"* OK [CAPABILITY IMAP4rev1]\r\n* PREAUTH\r\n";
+    let protocol = check_imap_greeting(DATA, None).unwrap();
+    assert_eq!(protocol, Protocol::Imap);
+}
+
+// Tests for insufficient data
+#[test]
+fn insufficient_min_length() {
+    const DATA: &[u8] = b"* O";
+    let result = check_imap_greeting(DATA, None);
+    assert!(matches!(result, Err(ProtocolInspectError::NeedMoreData(3))));
+}
+
+#[test]
+fn insufficient_preauth_length() {
+    const DATA: &[u8] = b"* PREA";
+    let result = check_imap_greeting(DATA, None);
+    assert!(matches!(result, Err(ProtocolInspectError::NeedMoreData(5))));
+}
+
+// Tests for invalid protocol markers
+#[test]
+fn invalid_first_byte() {
+    let mut data = Vec::from("X OK Invalid ");
+    data.extend(vec![b'X'; 54]);
+    data.extend(b"\r\n");
+
+    let protocol = check_imap_greeting(&data, None).unwrap();
+    assert_eq!(protocol, Protocol::Unknown);
+}
+
+#[test]
+fn missing_space_after_star() {
+    const DATA: &[u8] = b"*XOK Missing space\r\n";
+    let protocol = check_imap_greeting(DATA, None).unwrap();
+    assert_eq!(protocol, Protocol::Unknown);
+}
+
+// Tests for invalid status words
+#[test]
+fn invalid_status_word() {
+    const DATA: &[u8] = b"* INVALID Status\r\n";
+    let protocol = check_imap_greeting(DATA, None).unwrap();
+    assert_eq!(protocol, Protocol::Unknown);
+}
+
+#[test]
+fn incomplete_ok() {
+    const DATA: &[u8] = b"* O Missing K\r\n";
+    let protocol = check_imap_greeting(DATA, None).unwrap();
+    assert_eq!(protocol, Protocol::Unknown);
+}
+
+#[test]
+fn incomplete_bye() {
+    const DATA: &[u8] = b"* BY Missing E\r\n";
+    let protocol = check_imap_greeting(DATA, None).unwrap();
+    assert_eq!(protocol, Protocol::Unknown);
+}
+
+// Tests for line endings
+#[test]
+fn missing_lf_ending() {
+    const DATA: &[u8] = b"* OK No LF";
+    let result = check_imap_greeting(DATA, None);
+    assert!(matches!(result, Err(ProtocolInspectError::NeedMoreData(1))));
+}
+
+#[test]
+fn invalid_ending_missing_cr() {
+    const DATA: &[u8] = b"* OK Missing CR\n";
+    let protocol = check_imap_greeting(DATA, None).unwrap();
+    assert_eq!(protocol, Protocol::Unknown);
+}
+
+#[test]
+fn invalid_ending_missing_lf() {
+    const DATA: &[u8] = b"* OK Missing LF\r";
+    let result = check_imap_greeting(DATA, None);
+    assert!(matches!(result, Err(ProtocolInspectError::NeedMoreData(1))));
+}
+
+// Tests for size limits
+#[test]
+fn size_limit_exceeded() {
+    let mut data = Vec::from("* OK ");
+    data.extend(vec![b'X'; 512]);
+
+    let protocol = check_imap_greeting(&data, None).unwrap();
+    assert_eq!(protocol, Protocol::Unknown);
+}
+
+#[test]
+fn size_limit_within_bounds() {
+    // Create response that's exactly 512 bytes long
+    let mut data = Vec::from("* OK ");
+    data.extend(vec![b'X'; 507]); // 5 + 507 = 512 bytes
+    data.extend(b"\r\n");
+
+    let protocol = check_imap_greeting(&data, None).unwrap();
+    assert_eq!(protocol, Protocol::Imap);
+}
+
+#[test]
+fn custom_size_limit() {
+    // Create response that's 600 bytes long but with custom limit
+    let mut data = Vec::from("* OK ");
+    data.extend(vec![b'X'; 595]); // 5 + 595 = 600 bytes
+    data.extend(b"\r\n");
+
+    let protocol = check_imap_greeting(&data, Some(1024)).unwrap();
+    assert_eq!(protocol, Protocol::Imap);
+}
+
+// Test protocol exclusion
+#[test]
+fn excludes_other_protocols() {
+    let mut inspector = ProtocolInspector::default();
+    let config = ProtocolInspectionConfig::default();
+
+    // First detect IMAP
+    const IMAP_DATA: &[u8] = b"* OK IMAP4rev1\r\n";
     let protocol = inspector
-        .check_server_initial_data(&config, 143, DATA)
+        .check_server_initial_data(&config, 143, IMAP_DATA)
         .unwrap();
+    assert_eq!(protocol, Protocol::Imap);
+
+    // Now try to detect FTP (should be excluded)
+    const FTP_DATA: &[u8] = b"220 FTP Server\r\n";
+    let protocol = inspector
+        .check_server_initial_data(&config, 21, FTP_DATA)
+        .unwrap();
+    assert_eq!(protocol, Protocol::Unknown);
+}
+
+// Test minimum valid responses
+#[test]
+fn minimum_valid_ok() {
+    const DATA: &[u8] = b"* OK\r\n";
+    let protocol = check_imap_greeting(DATA, None).unwrap();
+    assert_eq!(protocol, Protocol::Imap);
+}
+
+#[test]
+fn minimum_valid_preauth() {
+    const DATA: &[u8] = b"* PREAUTH\r\n";
+    let protocol = check_imap_greeting(DATA, None).unwrap();
+    assert_eq!(protocol, Protocol::Imap);
+}
+
+#[test]
+fn minimum_valid_bye() {
+    const DATA: &[u8] = b"* BYE\r\n";
+    let protocol = check_imap_greeting(DATA, None).unwrap();
     assert_eq!(protocol, Protocol::Imap);
 }

--- a/lib/g3-dpi/tests/nats.rs
+++ b/lib/g3-dpi/tests/nats.rs
@@ -3,18 +3,90 @@
  * Copyright 2023-2025 ByteDance and/or its affiliates.
  */
 
-use g3_dpi::{Protocol, ProtocolInspectionConfig, ProtocolInspector};
+use g3_dpi::{
+    MaybeProtocol, Protocol, ProtocolInspectError, ProtocolInspectionConfig, ProtocolInspector,
+};
+
+// Helper function to check NATS server info message
+fn check_nats_data(
+    data: &[u8],
+    port: u16,
+    size_limit: Option<usize>,
+) -> Result<Protocol, ProtocolInspectError> {
+    let mut inspector = ProtocolInspector::default();
+    let mut config = ProtocolInspectionConfig::default();
+
+    // Apply custom size limit if provided
+    if let Some(limit) = size_limit {
+        config.size_limit_mut().set_nats_server_info_line(limit);
+    }
+
+    inspector.push_protocol(MaybeProtocol::Nats);
+    inspector.check_server_initial_data(&config, port, data)
+}
 
 #[test]
 fn port4222_demo() {
-    let mut inspector = ProtocolInspector::default();
-    let config = ProtocolInspectionConfig::default();
-
     const DATA: &[u8] =
         b"INFO {\"server_id\":\"Zk0GQ3JBSrg3oyxCRRlE09\",\"version\":\"1.2.0\",\"proto\":1,\"go\":\"go1.10.3\",\"host\":\"0.0.0.0\",\"port\":4222,\"max_payload\":1048576,\"client_id\":2392}\r\n";
+    let protocol = check_nats_data(DATA, 4222, None).unwrap();
+    assert_eq!(protocol, Protocol::Nats);
+}
 
-    let protocol = inspector
-        .check_server_initial_data(&config, 4222, DATA)
-        .unwrap();
+#[test]
+fn insufficient_data() {
+    // Data length < MINIMUM_DATA_LEN(10)
+    const DATA: &[u8] = b"INFO {";
+    let result = check_nats_data(DATA, 4222, None);
+    assert!(matches!(result, Err(ProtocolInspectError::NeedMoreData(4))));
+}
+
+#[test]
+fn invalid_first_byte() {
+    // First byte not 'I'
+    const DATA: &[u8] =
+        b"XINFO {\"server_id\":\"Zk0GQ3JBSrg3oyxCRRlE09\",\"version\":\"1.2.0\",\"proto\":1,\"go\":\"go1.10.3\",\"host\":\"0.0.0.0\",\"port\":4222,\"max_payload\":1048576,\"client_id\":2392}\r\n";
+    let protocol = check_nats_data(DATA, 4222, None).unwrap();
+    assert_eq!(protocol, Protocol::Unknown);
+}
+
+#[test]
+fn invalid_prefix() {
+    // Does not start with "INFO {"
+    const DATA: &[u8] = b"INFOX{\"test\":1}\r\n";
+    let protocol = check_nats_data(DATA, 4222, None).unwrap();
+    assert_eq!(protocol, Protocol::Unknown);
+}
+
+#[test]
+fn missing_newline() {
+    // No newline at end (within size limit)
+    const DATA: &[u8] = b"INFO {\"test\":1}";
+    let result = check_nats_data(DATA, 4222, None);
+    assert!(matches!(result, Err(ProtocolInspectError::NeedMoreData(1))));
+}
+
+#[test]
+fn missing_newline_exceeds_limit() {
+    // No newline at end (exceeds size limit)
+    let mut data = vec![0u8; 1025]; // Exceeds default 1024 limit
+    data[0..6].copy_from_slice(b"INFO {");
+    let protocol = check_nats_data(&data, 4222, Some(10)).unwrap();
+    assert_eq!(protocol, Protocol::Unknown);
+}
+
+#[test]
+fn missing_carriage_return() {
+    // Ends with '\n' but missing preceding '\r'
+    const DATA: &[u8] = b"INFO {\"test\":1}\n";
+    let protocol = check_nats_data(DATA, 4222, None).unwrap();
+    assert_eq!(protocol, Protocol::Unknown);
+}
+
+#[test]
+fn valid_minimal_data() {
+    // Minimal valid data with \r\n ending
+    const DATA: &[u8] = b"INFO { }\r\n";
+    let protocol = check_nats_data(DATA, 4222, None).unwrap();
     assert_eq!(protocol, Protocol::Nats);
 }

--- a/lib/g3-dpi/tests/nntp.rs
+++ b/lib/g3-dpi/tests/nntp.rs
@@ -3,18 +3,104 @@
  * Copyright 2023-2025 ByteDance and/or its affiliates.
  */
 
-use g3_dpi::{Protocol, ProtocolInspectionConfig, ProtocolInspector};
+use g3_dpi::{
+    MaybeProtocol, Protocol, ProtocolInspectError, ProtocolInspectionConfig, ProtocolInspector,
+};
+
+// Helper function to check NNTP server greeting
+fn check_nntp_greeting(data: &[u8], port: u16) -> Result<Protocol, ProtocolInspectError> {
+    let mut inspector = ProtocolInspector::default();
+    // Prioritize NNTP detection
+    inspector.push_protocol(MaybeProtocol::Nntp);
+    let config = ProtocolInspectionConfig::default();
+    inspector.check_server_initial_data(&config, port, data)
+}
+
+// Tests for valid NNTP responses
+#[test]
+fn port119_valid_response() {
+    const DATA: &[u8] =
+        b"200 news.gmane.io InterNetNews NNRP server INN 2.6.3 ready (posting ok)\r\n";
+    let protocol = check_nntp_greeting(DATA, 119).unwrap();
+    assert_eq!(protocol, Protocol::Nntp);
+}
+
+// Tests for data length boundaries
+#[test]
+fn insufficient_data_less_than_min() {
+    const DATA: &[u8] = b"1234"; // 4 bytes < min 5
+    let result = check_nntp_greeting(DATA, 119);
+    assert!(matches!(result, Err(ProtocolInspectError::NeedMoreData(1))));
+}
 
 #[test]
-fn port119_gmane() {
+fn excess_data_over_max() {
+    // Create 513-byte response
+    let mut data = Vec::from("200 ");
+    data.extend(vec![b'A'; 509]); // 4 + 509 = 513 bytes
+    let protocol = check_nntp_greeting(&data, 119).unwrap();
+    assert_eq!(protocol, Protocol::Unknown);
+}
+
+// Tests for byte sequence validation
+#[test]
+fn invalid_first_byte() {
+    // First byte not '2' (0x32)
+    let mut data = Vec::from("300 Invalid response\r\n");
+    data.extend(vec![b'A'; 100]);
+    let protocol = check_nntp_greeting(&data, 119).unwrap();
+    assert_eq!(protocol, Protocol::Unknown);
+}
+
+#[test]
+fn invalid_second_byte() {
+    // Second byte not '0'
+    const DATA: &[u8] = b"230 Invalid response\r\n";
+    let protocol = check_nntp_greeting(DATA, 119).unwrap();
+    assert_eq!(protocol, Protocol::Unknown);
+}
+
+#[test]
+fn invalid_third_byte() {
+    // Third byte not '0' or '1'
+    const DATA: &[u8] = b"202 Invalid response\r\n"; // Third byte '2'
+    let protocol = check_nntp_greeting(DATA, 119).unwrap();
+    assert_eq!(protocol, Protocol::Unknown);
+}
+
+#[test]
+fn missing_carriage_return() {
+    // No '\r' before '\n'
+    const DATA: &[u8] = b"200 Server ready\n";
+    let protocol = check_nntp_greeting(DATA, 119).unwrap();
+    assert_eq!(protocol, Protocol::Unknown);
+}
+
+#[test]
+fn missing_line_feed() {
+    // Ends with '\r' but no '\n'
+    const DATA: &[u8] = b"200 Server ready\r";
+    let result = check_nntp_greeting(DATA, 119);
+    assert!(matches!(result, Err(ProtocolInspectError::NeedMoreData(1))));
+}
+
+// Test protocol exclusion
+#[test]
+fn excludes_protocols_after_checks() {
     let mut inspector = ProtocolInspector::default();
     let config = ProtocolInspectionConfig::default();
 
-    const DATA: &[u8] =
-        b"200 news.gmane.io InterNetNews NNRP server INN 2.6.3 ready (posting ok)\r\n";
-
+    // First check NNTP response
+    const NNTP_DATA: &[u8] = b"200 Server ready\r\n";
     let protocol = inspector
-        .check_server_initial_data(&config, 119, DATA)
+        .check_server_initial_data(&config, 119, NNTP_DATA)
         .unwrap();
     assert_eq!(protocol, Protocol::Nntp);
+
+    // Now check SSH (should be excluded)
+    const SSH_DATA: &[u8] = b"SSH-2.0-OpenSSH";
+    let protocol = inspector
+        .check_server_initial_data(&config, 22, SSH_DATA)
+        .unwrap();
+    assert_eq!(protocol, Protocol::Unknown);
 }

--- a/lib/g3-dpi/tests/pop3.rs
+++ b/lib/g3-dpi/tests/pop3.rs
@@ -3,18 +3,108 @@
  * Copyright 2023-2025 ByteDance and/or its affiliates.
  */
 
-use g3_dpi::{Protocol, ProtocolInspectionConfig, ProtocolInspector};
+use g3_dpi::{
+    MaybeProtocol, Protocol, ProtocolInspectError, ProtocolInspectionConfig, ProtocolInspector,
+};
+
+// Helper function to check POP3 server greeting
+fn check_pop3_greeting(data: &[u8], port: u16) -> Result<Protocol, ProtocolInspectError> {
+    let mut inspector = ProtocolInspector::default();
+    // Push Pop3 to ensure it's checked first
+    inspector.push_protocol(MaybeProtocol::Pop3);
+    let config = ProtocolInspectionConfig::default();
+    inspector.check_server_initial_data(&config, port, data)
+}
 
 #[test]
 fn port110_outlook() {
+    const DATA: &[u8] =
+        b"+OK The Microsoft Exchange POP3 service is ready. [UwBHADIAUABSADAAMwBDAEEAMAAwADkANwAuAGEAcABjAHAAcgBkADAAMwAuAHAAcgBvAGQALgBvAHUAdABsAG8AbwBrAC4AYwBvAG0A]\r\n";
+    let protocol = check_pop3_greeting(DATA, 110).unwrap();
+    assert_eq!(protocol, Protocol::Pop3);
+}
+
+#[test]
+fn valid_ok_response() {
+    // Test minimal valid POP3 response
+    const DATA: &[u8] = b"+OK\r\n";
+    let protocol = check_pop3_greeting(DATA, 110).unwrap();
+    assert_eq!(protocol, Protocol::Pop3);
+}
+
+#[test]
+fn valid_response_with_message() {
+    // Test response with additional message
+    const DATA: &[u8] = b"+OK POP3 server ready\r\n";
+    let protocol = check_pop3_greeting(DATA, 110).unwrap();
+    assert_eq!(protocol, Protocol::Pop3);
+}
+
+#[test]
+fn insufficient_data_length() {
+    // Test data shorter than minimum required length (5 bytes)
+    const DATA: &[u8] = b"+OK";
+    let result = check_pop3_greeting(DATA, 110);
+    assert!(matches!(result, Err(ProtocolInspectError::NeedMoreData(2))));
+}
+
+#[test]
+fn excessive_data_length() {
+    // Test data longer than maximum allowed length (512 bytes)
+    let data: Vec<u8> = vec![b'+'; 513];
+    let protocol = check_pop3_greeting(&data, 110).unwrap();
+    assert_eq!(protocol, Protocol::Unknown);
+}
+
+#[test]
+fn invalid_first_byte() {
+    // Test response starting with '-' instead of '+'
+    let data: Vec<u8> = vec![b'-'; 512];
+    let protocol = check_pop3_greeting(&data, 110).unwrap();
+    assert_eq!(protocol, Protocol::Unknown);
+}
+
+#[test]
+fn missing_ok_keyword() {
+    // Test response with '+' but without "OK"
+    const DATA: &[u8] = b"+HELLO\r\n";
+    let protocol = check_pop3_greeting(DATA, 110).unwrap();
+    assert_eq!(protocol, Protocol::Unknown);
+}
+
+#[test]
+fn invalid_line_ending_missing_cr() {
+    // Test response with LF but no CR
+    const DATA: &[u8] = b"+OK POP3 server ready\n";
+    let protocol = check_pop3_greeting(DATA, 110).unwrap();
+    assert_eq!(protocol, Protocol::Unknown);
+}
+
+#[test]
+fn invalid_line_ending_missing_lf() {
+    // Test response with CR but no LF
+    const DATA: &[u8] = b"+OK POP3 server ready\r";
+    let result = check_pop3_greeting(DATA, 110);
+    assert!(matches!(result, Err(ProtocolInspectError::NeedMoreData(1))));
+}
+
+#[test]
+fn protocol_exclusion_after_detection() {
+    // Test that POP3 detection excludes other protocols
     let mut inspector = ProtocolInspector::default();
     let config = ProtocolInspectionConfig::default();
 
-    const DATA: &[u8] =
-        b"+OK The Microsoft Exchange POP3 service is ready. [UwBHADIAUABSADAAMwBDAEEAMAAwADkANwAuAGEAcABjAHAAcgBkADAAMwAuAHAAcgBvAGQALgBvAHUAdABsAG8AbwBrAC4AYwBvAG0A]\r\n";
-
+    // First detect POP3
+    const POP3_DATA: &[u8] = b"+OK\r\n";
     let protocol = inspector
-        .check_server_initial_data(&config, 110, DATA)
+        .check_server_initial_data(&config, 110, POP3_DATA)
         .unwrap();
     assert_eq!(protocol, Protocol::Pop3);
+
+    // Now try to detect FTP (should be excluded)
+    const FTP_DATA: &[u8] = b"220 FTP Server\r\n";
+    let protocol = inspector
+        .check_server_initial_data(&config, 21, FTP_DATA)
+        .unwrap();
+    assert_eq!(protocol, Protocol::Unknown);
 }

--- a/lib/g3-dpi/tests/smtp.rs
+++ b/lib/g3-dpi/tests/smtp.rs
@@ -3,18 +3,108 @@
  * Copyright 2023-2025 ByteDance and/or its affiliates.
  */
 
-use g3_dpi::{Protocol, ProtocolInspectionConfig, ProtocolInspector};
+use g3_dpi::{
+    MaybeProtocol, Protocol, ProtocolInspectError, ProtocolInspectionConfig, ProtocolInspector,
+};
+
+// Helper function to check SMTP server greeting
+fn check_smtp_server_greeting(data: &[u8], port: u16) -> Result<Protocol, ProtocolInspectError> {
+    let mut inspector = ProtocolInspector::default();
+    inspector.push_protocol(MaybeProtocol::Smtp);
+    let config = ProtocolInspectionConfig::default();
+    inspector.check_server_initial_data(&config, port, data)
+}
 
 #[test]
-fn port25_220_gmail() {
-    let mut inspector = ProtocolInspector::default();
-    let config = ProtocolInspectionConfig::default();
-
+fn valid_220_response() {
     const DATA: &[u8] =
         b"220 smtp.gmail.com ESMTP 68-20020a620647000000b00545832dd969sm8803280pfg.145 - gsmtp\r\n";
-
-    let protocol = inspector
-        .check_server_initial_data(&config, 25, DATA)
-        .unwrap();
+    let protocol = check_smtp_server_greeting(DATA, 25).unwrap();
     assert_eq!(protocol, Protocol::Smtp);
+}
+
+#[test]
+fn valid_554_response() {
+    const DATA: &[u8] = b"554 Transaction failed\r\n";
+    let protocol = check_smtp_server_greeting(DATA, 25).unwrap();
+    assert_eq!(protocol, Protocol::Smtp);
+}
+
+#[test]
+fn invalid_second_byte() {
+    const DATA: &[u8] = b"230 Invalid response\r\n";
+    let protocol = check_smtp_server_greeting(DATA, 25).unwrap();
+    assert_eq!(protocol, Protocol::Unknown);
+}
+
+#[test]
+fn invalid_third_byte() {
+    const DATA: &[u8] = b"225 No new messages\r\n";
+    let protocol = check_smtp_server_greeting(DATA, 25).unwrap();
+    assert_eq!(protocol, Protocol::Unknown);
+}
+
+#[test]
+fn non_554_five_series() {
+    const DATA: &[u8] = b"550 Invalid user\r\n";
+    let protocol = check_smtp_server_greeting(DATA, 25).unwrap();
+    assert_eq!(protocol, Protocol::Unknown);
+}
+
+#[test]
+fn non_2_or_5_first_byte() {
+    let mut data = vec![b'3'; 600];
+    data.extend(b"\r\n");
+    let protocol = check_smtp_server_greeting(&data, 25).unwrap();
+    assert_eq!(protocol, Protocol::Unknown);
+}
+
+#[test]
+fn invalid_separator_after_code() {
+    const DATA: &[u8] = b"220XInvalid response\r\n";
+    let protocol = check_smtp_server_greeting(DATA, 25).unwrap();
+    assert_eq!(protocol, Protocol::Unknown);
+}
+
+#[test]
+fn newline_at_start() {
+    const DATA: &[u8] = b"554   \n";
+    let protocol = check_smtp_server_greeting(DATA, 25).unwrap();
+    assert_eq!(protocol, Protocol::Unknown);
+}
+
+#[test]
+fn missing_cr_before_lf() {
+    const DATA: &[u8] = b"554 example.com\n";
+    let protocol = check_smtp_server_greeting(DATA, 25).unwrap();
+    assert_eq!(protocol, Protocol::Unknown);
+}
+
+#[test]
+fn valid_ipv4_host() {
+    const DATA: &[u8] = b"220 192.0.2.1\r\n";
+    let protocol = check_smtp_server_greeting(DATA, 25).unwrap();
+    assert_eq!(protocol, Protocol::Smtp);
+}
+
+#[test]
+fn line_too_short() {
+    const DATA: &[u8] = b"554\r\n";
+    let result = check_smtp_server_greeting(DATA, 25);
+    assert!(matches!(result, Err(ProtocolInspectError::NeedMoreData(1))));
+}
+
+#[test]
+fn line_too_long() {
+    let mut data = vec![b'2'; 600];
+    data.extend(b"\r\n");
+    let protocol = check_smtp_server_greeting(&data, 25).unwrap();
+    assert_eq!(protocol, Protocol::Unknown);
+}
+
+#[test]
+fn need_more_data() {
+    const DATA: &[u8] = b"220 incomplete";
+    let result = check_smtp_server_greeting(DATA, 25);
+    assert!(matches!(result, Err(ProtocolInspectError::NeedMoreData(1))));
 }


### PR DESCRIPTION
This commit adds extensive tests for server initial data protocol detection across FTP, HTTP, IMAP, NATS, NNTP, POP3, and  SMTP services. The new tests cover valid server greetings, invalid responses, data length boundaries, line ending variations, and protocol exclusion behavior after detection.

## CI Process
<img width="1678" height="753" alt="截图 2025-08-07 02-26-02" src="https://github.com/user-attachments/assets/97e58249-8f53-4d5a-af88-19d4c2e8886c" />

## Codecov Data
<img width="2541" height="1376" alt="截图 2025-08-07 02-26-58" src="https://github.com/user-attachments/assets/4b8e5439-52b9-45ff-bd78-9f676a9a7f79" />
