### PR TITLE
add unit tests for YAML configuration parsing

### DIFF
--- a/lib/g3-ip-locate/src/config/yaml.rs
+++ b/lib/g3-ip-locate/src/config/yaml.rs
@@ -78,3 +78,129 @@ impl IpLocateServiceConfig {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use g3_yaml::{yaml_doc, yaml_str};
+    use yaml_rust::YamlLoader;
+
+    #[test]
+    fn parse_map_ok() {
+        let yaml = yaml_doc!(
+            r#"
+                cache_request_batch_count: 20
+                cache_request_timeout: "5s"
+                query_peer_addr: "192.168.1.1:2888"
+                query_socket_buffer:
+                  recv: 65536
+                  send: 32768
+                query_wait_timeout: "2s"
+                default_expire_ttl: 30
+                maximum_expire_ttl: 600
+            "#
+        );
+        let config = IpLocateServiceConfig::parse_yaml(&yaml).unwrap();
+        assert_eq!(config.cache_request_batch_count, 20);
+        assert_eq!(
+            config.cache_request_timeout,
+            std::time::Duration::from_secs(5)
+        );
+        assert_eq!(config.query_peer_addr, "192.168.1.1:2888".parse().unwrap());
+        assert_eq!(config.query_socket_buffer.recv_size(), Some(65536));
+        assert_eq!(config.query_socket_buffer.send_size(), Some(32768));
+        assert_eq!(config.query_wait_timeout, std::time::Duration::from_secs(2));
+        assert_eq!(config.default_expire_ttl, 30);
+        assert_eq!(config.maximum_expire_ttl, 600);
+    }
+
+    #[test]
+    fn parse_map_err() {
+        let yaml = yaml_doc!(
+            r#"
+                invalid_key: "value"
+            "#
+        );
+        assert!(IpLocateServiceConfig::parse_yaml(&yaml).is_err());
+
+        let yaml = yaml_doc!(
+            r#"
+                cache_request_batch_count: -1
+            "#
+        );
+        assert!(IpLocateServiceConfig::parse_yaml(&yaml).is_err());
+
+        let yaml = yaml_doc!(
+            r#"
+                cache_request_timeout: "5x"
+            "#
+        );
+        assert!(IpLocateServiceConfig::parse_yaml(&yaml).is_err());
+
+        let yaml = yaml_doc!(
+            r#"
+                query_peer_addr: "invalid_address"
+            "#
+        );
+        assert!(IpLocateServiceConfig::parse_yaml(&yaml).is_err());
+
+        let yaml = yaml_doc!(
+            r#"
+                query_socket_buffer:
+                  recv: -1024
+            "#
+        );
+        assert!(IpLocateServiceConfig::parse_yaml(&yaml).is_err());
+
+        let yaml = yaml_doc!(
+            r#"
+                query_wait_timeout: "-1s"
+            "#
+        );
+        assert!(IpLocateServiceConfig::parse_yaml(&yaml).is_err());
+
+        let yaml = yaml_doc!(
+            r#"
+                default_expire_ttl: -10
+            "#
+        );
+        assert!(IpLocateServiceConfig::parse_yaml(&yaml).is_err());
+
+        let yaml = yaml_doc!(
+            r#"
+                maximum_expire_ttl: NaN
+            "#
+        );
+        assert!(IpLocateServiceConfig::parse_yaml(&yaml).is_err());
+    }
+
+    #[test]
+    fn parse_string() {
+        // Valid address
+        let yaml = yaml_str!("127.0.0.1:3000");
+        let config = IpLocateServiceConfig::parse_yaml(&yaml).unwrap();
+        assert_eq!(config.query_peer_addr, "127.0.0.1:3000".parse().unwrap());
+
+        // Invalid address
+        let yaml = yaml_str!("invalid-address");
+        assert!(IpLocateServiceConfig::parse_yaml(&yaml).is_err());
+    }
+
+    #[test]
+    fn parse_invalid_yaml_types() {
+        let yaml = Yaml::Array(vec![]);
+        assert!(IpLocateServiceConfig::parse_yaml(&yaml).is_err());
+
+        let yaml = Yaml::Integer(123);
+        assert!(IpLocateServiceConfig::parse_yaml(&yaml).is_err());
+
+        let yaml = Yaml::Boolean(true);
+        assert!(IpLocateServiceConfig::parse_yaml(&yaml).is_err());
+
+        let yaml = Yaml::Real("1.23".to_string());
+        assert!(IpLocateServiceConfig::parse_yaml(&yaml).is_err());
+
+        let yaml = Yaml::Null;
+        assert!(IpLocateServiceConfig::parse_yaml(&yaml).is_err());
+    }
+}

--- a/lib/g3-tls-ticket/src/config/yaml.rs
+++ b/lib/g3-tls-ticket/src/config/yaml.rs
@@ -42,3 +42,89 @@ impl TlsTicketConfig {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use g3_yaml::yaml_doc;
+    use yaml_rust::YamlLoader;
+
+    #[test]
+    fn parse_map_ok() {
+        let yaml = yaml_doc!(
+            r#"
+                check_interval: "600s"
+                local_lifetime: 43200
+                source:
+                  type: "redis"
+                  addr: "127.0.0.1:6379"
+                  db: 0
+                  enc_key: "tls_ticket_enc"
+                  dec_set: "tls_ticket_dec"
+            "#
+        );
+        let config = TlsTicketConfig::parse_yaml(&yaml, None).unwrap();
+        assert_eq!(config.check_interval, std::time::Duration::from_secs(600));
+        assert_eq!(config.local_lifetime, 43200);
+        assert!(config.remote_source.is_some());
+
+        let yaml = yaml_doc!(
+            r#"
+                check_interval: "300s"
+            "#
+        );
+        let config = TlsTicketConfig::parse_yaml(&yaml, None).unwrap();
+        assert_eq!(config.check_interval, std::time::Duration::from_secs(300));
+        assert_eq!(config.local_lifetime, 12 * 60 * 60);
+        assert!(config.remote_source.is_none());
+    }
+
+    #[test]
+    fn parse_map_err() {
+        let yaml = yaml_doc!(
+            r#"
+                invalid_key: "value"
+            "#
+        );
+        assert!(TlsTicketConfig::parse_yaml(&yaml, None).is_err());
+
+        let yaml = yaml_doc!(
+            r#"
+                check_interval: "300x"
+            "#
+        );
+        assert!(TlsTicketConfig::parse_yaml(&yaml, None).is_err());
+
+        let yaml = yaml_doc!(
+            r#"
+                local_lifetime: -1
+            "#
+        );
+        assert!(TlsTicketConfig::parse_yaml(&yaml, None).is_err());
+
+        let yaml = yaml_doc!(
+            r#"
+                source: "invalid_source"
+            "#
+        );
+        assert!(TlsTicketConfig::parse_yaml(&yaml, None).is_err());
+    }
+
+    #[test]
+    fn parse_invalid_yaml_types() {
+        let yaml = Yaml::Array(vec![]);
+        assert!(TlsTicketConfig::parse_yaml(&yaml, None).is_err());
+
+        let yaml = Yaml::Integer(123);
+        assert!(TlsTicketConfig::parse_yaml(&yaml, None).is_err());
+
+        let yaml = Yaml::Boolean(true);
+        assert!(TlsTicketConfig::parse_yaml(&yaml, None).is_err());
+
+        let yaml = Yaml::Real("1.23".to_string());
+        assert!(TlsTicketConfig::parse_yaml(&yaml, None).is_err());
+
+        let yaml = Yaml::Null;
+        assert!(TlsTicketConfig::parse_yaml(&yaml, None).is_err());
+    }
+}

--- a/lib/g3-tls-ticket/src/source/redis/yaml.rs
+++ b/lib/g3-tls-ticket/src/source/redis/yaml.rs
@@ -34,3 +34,71 @@ impl RedisSourceConfig {
         Ok(config)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use g3_yaml::yaml_doc;
+    use yaml_rust::YamlLoader;
+
+    #[test]
+    fn parse_yaml_map_ok() {
+        let yaml = yaml_doc!(
+            r#"
+                type: "redis"
+                enc_key: "tls_ticket_enc"
+                dec_set: "tls_ticket_dec"
+                addr: "127.0.0.1:6379"
+                db: 0
+            "#
+        );
+        let config = RedisSourceConfig::parse_yaml_map(yaml.as_hash().unwrap(), None).unwrap();
+        assert_eq!(config.enc_key_name, "tls_ticket_enc");
+        assert_eq!(config.dec_set_name, "tls_ticket_dec");
+    }
+
+    #[test]
+    fn parse_yaml_map_err() {
+        // Missing enc_key
+        let yaml = yaml_doc!(
+            r#"
+                type: "redis"
+                dec_set: "tls_ticket_dec"
+                addr: "127.0.0.1:6379"
+            "#
+        );
+        assert!(RedisSourceConfig::parse_yaml_map(yaml.as_hash().unwrap(), None).is_err());
+
+        // Missing dec_set
+        let yaml = yaml_doc!(
+            r#"
+                type: "redis"
+                enc_key: "tls_ticket_enc"
+                addr: "127.0.0.1:6379"
+            "#
+        );
+        assert!(RedisSourceConfig::parse_yaml_map(yaml.as_hash().unwrap(), None).is_err());
+
+        // Empty enc_key
+        let yaml = yaml_doc!(
+            r#"
+                type: "redis"
+                enc_key: ""
+                dec_set: "tls_ticket_dec"
+                addr: "127.0.0.1:6379"
+            "#
+        );
+        assert!(RedisSourceConfig::parse_yaml_map(yaml.as_hash().unwrap(), None).is_err());
+
+        // Empty dec_set
+        let yaml = yaml_doc!(
+            r#"
+                type: "redis"
+                enc_key: "tls_ticket_enc"
+                dec_set: ""
+                addr: "127.0.0.1:6379"
+            "#
+        );
+        assert!(RedisSourceConfig::parse_yaml_map(yaml.as_hash().unwrap(), None).is_err());
+    }
+}


### PR DESCRIPTION
add unit tests for YAML configuration parsing in g3-ip-locate, g3-redis-client, g3-statsd-client, g3-tls-ticket, and g3-udpdump.