### PR TITLE
Username params to escaper address

### DIFF
--- a/g3proxy/UserGuide.en_US.md
+++ b/g3proxy/UserGuide.en_US.md
@@ -334,6 +334,47 @@ escaper:
     tls_name: example.com # If the proxy address does not contain a domain name, and you need to verify the certificate with DNS Name, you need to set it
 ```
 
+#### Username Params → Next-Hop Escaper
+
+For HTTP and SOCKS5 proxy servers, you can derive the chained next-hop address from the client username by appending
+ordered key-value pairs after the base name: `base+key1=val1+key2=val2+...`.
+
+- Enable per server with `username_params_to_escaper_addr`.
+- The host is built by joining configured keys’ values using a separator; with no keys, a `global_label` is used.
+- The port is selected based on inbound protocol (HTTP/SOCKS5), both configurable.
+- Unknown keys and hierarchy violations (e.g., child without parent) can be rejected.
+
+Example configuration:
+
+```yaml
+server:
+  - name: http-in
+    type: http_proxy
+    escaper: chain
+    username_params_to_escaper_addr:
+      keys_for_host: [label1, label2, label3]
+      require_hierarchy: true
+      reject_unknown_keys: true
+      reject_duplicate_keys: true
+      separator: "-"
+      # Optional suffix (e.g., for local testing):
+      # domain_suffix: ".localhost"
+      global_label: "global"
+      http_port: 10000
+      socks5_port: 10001
+      strip_suffix_for_auth: true
+```
+
+Behavior:
+- Username `user+label1=foo+label2=bar` → host `foo-bar`, port `10000` for HTTP inbound.
+- Invalid params cause HTTP 400 Bad Request; SOCKS5 replies with a standard error code and denies the request.
+
+Escaper fallback note:
+- Proxy chaining escapers (proxy_http/proxy_socks5/…) must define at least one `proxy_addr` to initialize.
+- When username params are present (and auth succeeds), the computed host:port overrides `proxy_addr` for that connection.
+- If you want a real fallback for requests without username params (e.g., anonymous), set `proxy_addr` to your default next‑hop
+  (for this example: HTTP → 127.0.0.1:10000, SOCKS5 → 127.0.0.1:10001). Otherwise the placeholder values are never used.
+
 ### Connection Throttling
 
 All servers, escapers, users support per-connection throttling. Set the same key in the corresponding server &

--- a/g3proxy/UserGuide.zh_CN.md
+++ b/g3proxy/UserGuide.zh_CN.md
@@ -312,6 +312,46 @@ escaper:
     tls_name: example.com # 代理地址不包含域名时，如果需要用DNS Name验证证书，则需要设置
 ```
 
+#### 用户名参数 → 串联下一跳地址
+
+对于 HTTP 和 SOCKS5 代理入口，可以通过在用户名后追加有序的键值对，动态计算串联下一跳的地址：`base+key1=val1+key2=val2+...`。
+
+- 在对应入口下启用 `username_params_to_escaper_addr` 即可生效。
+- 计算主机名：按配置的键顺序取值并用分隔符拼接；未提供键值时使用 `global_label`。
+- 端口：根据入站协议选择（HTTP / SOCKS5），均可配置。
+- 可配置是否拒绝未知键、是否强制层级（例如子键必须有父键）。
+
+示例配置：
+
+```yaml
+server:
+  - name: http-in
+    type: http_proxy
+    escaper: chain
+    username_params_to_escaper_addr:
+      keys_for_host: [label1, label2, label3]
+      require_hierarchy: true
+      reject_unknown_keys: true
+      reject_duplicate_keys: true
+      separator: "-"
+      # 可选后缀（例如本地测试）：
+      # domain_suffix: ".localhost"
+      global_label: "global"
+      http_port: 10000
+      socks5_port: 10001
+      strip_suffix_for_auth: true
+```
+
+行为说明：
+- 用户名 `user+label1=foo+label2=bar` → 主机 `foo-bar`，HTTP 入站端口 `10000`。
+- 非法参数（未知键或层级违例）会导致 HTTP 返回 400 Bad Request；SOCKS5 返回标准错误码并拒绝请求。
+
+出口回退说明：
+- 代理串联出口（proxy_http / proxy_socks5 / …）在初始化时必须配置至少一个 `proxy_addr`。
+- 当用户名参数存在且认证成功时，计算得到的 host:port 会覆盖该连接的 `proxy_addr`。
+- 如果希望对“未提供用户名参数”的请求提供真实回退路径（例如允许匿名），请将 `proxy_addr` 设置为默认下一跳
+  （本示例可用：HTTP → 127.0.0.1:10000，SOCKS5 → 127.0.0.1:10001）。否则示例中的占位值不会被使用。
+
 ### 连接限速
 
 server、escaper、user维度均支持设置单连接限速，配置key相同，在对应的server & escaper & user里设置：

--- a/g3proxy/examples/username-params-escaper/g3proxy.yaml
+++ b/g3proxy/examples/username-params-escaper/g3proxy.yaml
@@ -1,0 +1,113 @@
+---
+# Minimal end-to-end example: derive next-hop escaper address from proxy username params.
+#
+# Highlights
+# - HTTP server on 13128 and SOCKS5 server on 11080
+# - Username format: base+key1=val1+key2=val2
+# - Keys are ordered and optional; hierarchy can be enforced (child requires parent)
+# - Computed service host = join(values, '-') or 'global' when no params
+# - Port chosen by inbound protocol: 10000 (HTTP), 10001 (SOCKS5)
+# - Base username is used for auth (suffix stripped)
+
+user_group:
+  - name: default
+    static_users:
+      - name: user
+        # DEMO ONLY: accept any password (token: null). For real use, set a token:
+        #   token:
+        #     salt: <hex>
+        #     md5:  <hex>
+        #     sha1: <hex>
+        # Or:
+        #   token: "$6$mysalt$..."
+        token: ~
+
+server:
+  - name: http-in
+    type: http_proxy
+    escaper: dyn_http_chain
+    user_group: default
+    listen:
+      # Bind IPv4 explicitly to avoid OS-dependent v6-only sockets
+      address: "127.0.0.1:13128"
+    # Map username params to next-hop escaper host:port
+    username_params_to_escaper_addr:
+      # Optional independent (floating) key 'opt' can appear alone or append hierarchically
+      keys_for_host: [label1, label2, label3, label4, opt]
+      floating_keys: [opt]
+      require_hierarchy: true
+      reject_unknown_keys: true
+      reject_duplicate_keys: true
+      separator: "-"
+      # for local testing use ".localhost"
+      # k8s note: c-ares doesn't expand ndots
+      # so use FQDN (e.g. domain_suffix: ".default.svc.cluster.local")
+      domain_suffix: ".localhost"
+      global_label: "global"
+      http_port: 10000
+      socks5_port: 10001
+      strip_suffix_for_auth: true
+
+  - name: socks-in
+    type: socks_proxy
+    escaper: dyn_socks_chain
+    user_group: default
+    listen:
+      # Bind IPv4 explicitly to avoid OS-dependent v6-only sockets
+      address: "127.0.0.1:11080"
+    enable_udp_associate: true
+    username_params_to_escaper_addr:
+      # Optional independent (floating) key 'opt' can appear alone or append hierarchically
+      keys_for_host: [label1, label2, label3, label4, opt]
+      floating_keys: [opt]
+      require_hierarchy: true
+      reject_unknown_keys: true
+      reject_duplicate_keys: true
+      separator: "-"
+      # for local testing use ".localhost"
+      # k8s note: c-ares doesn't expand ndots
+      # so use FQDN (e.g. domain_suffix: ".default.svc.cluster.local")
+      domain_suffix: ".localhost"
+      global_label: "global"
+      http_port: 10000
+      socks5_port: 10001
+      strip_suffix_for_auth: true
+
+resolver:
+  - name: sys
+    type: c-ares
+
+escaper:
+  # NOTE ABOUT proxy_addr BELOW
+  # - proxy_addr is required by proxy_* escapers so they can initialize.
+  # - In this example, the next-hop is computed from the username params per connection,
+  #   so these proxy_addr values are placeholders and are NOT used when params are present.
+  # - If you want a meaningful fallback (e.g., when no username params are supplied
+  #   and you allow anonymous), set proxy_addr to your actual default next-hop, e.g.:
+  #     HTTP  -> 127.0.0.1:10000
+  #     SOCKS -> 127.0.0.1:10001
+
+  # HTTP chaining escaper; overridden per-connection by computed host:port
+  - name: dyn_http_chain
+    type: proxy_http
+    resolver: sys
+    proxy_addr:
+      - "127.0.0.1:3128"   # fallback only; overridden when username params present
+
+  # SOCKS5 chaining escaper; overridden per-connection by computed host:port
+  - name: dyn_socks_chain
+    type: proxy_socks5
+    resolver: sys
+    proxy_addr:
+      - "127.0.0.1:1080"   # fallback only; overridden when username params present
+
+# Testing tips
+# - HTTP:  curl -x http://user+label1=foo+label2=bar:password123@127.0.0.1:8080 http://example.com/
+#   => chosen svc: foo-bar:10000 (mapped to 127.0.0.1:10000)
+# - SOCKS5: curl --socks5 user+label1=foo+label2=bar:password123@127.0.0.1:11080 http://example.com/
+#   => chosen svc: foo-bar:10001 (mapped to 127.0.0.1:10001)
+# - Floating only (independent): curl -x http://user+opt=o123:password@127.0.0.1:8080 http://example.com/
+#   => chosen svc: o123:10000
+# - Combined (hierarchical + floating): curl -x http://user+label1=foo+opt=o123:password@127.0.0.1:8080 http://example.com/
+#   => chosen svc: foo-o123:10000
+log: stdout

--- a/g3proxy/src/config/server/mod.rs
+++ b/g3proxy/src/config/server/mod.rs
@@ -34,6 +34,7 @@ pub(crate) mod http_rproxy;
 pub(crate) mod sni_proxy;
 pub(crate) mod socks_proxy;
 pub(crate) mod tcp_stream;
+pub(crate) mod username_params_to_escaper;
 #[cfg(any(
     target_os = "linux",
     target_os = "freebsd",

--- a/g3proxy/src/config/server/username_params_to_escaper.rs
+++ b/g3proxy/src/config/server/username_params_to_escaper.rs
@@ -1,0 +1,153 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright 2025 ByteDance and/or its affiliates.
+ */
+
+use std::borrow::Cow;
+
+use anyhow::{Context, anyhow};
+use yaml_rust::{Yaml, yaml};
+
+use g3_yaml::YamlDocPosition;
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct UsernameParamsToEscaperConfig {
+    position: Option<YamlDocPosition>,
+    /// ordered keys that will be used to form the host label
+    pub(crate) keys_for_host: Vec<String>,
+    /// require that if a later key appears, all its ancestors (earlier keys) must also appear
+    pub(crate) require_hierarchy: bool,
+    /// keys that can appear independently without requiring earlier keys (e.g., a generic optional key)
+    pub(crate) floating_keys: Vec<String>,
+    /// reject unknown keys not present in `keys_for_host`
+    pub(crate) reject_unknown_keys: bool,
+    /// reject duplicate keys
+    pub(crate) reject_duplicate_keys: bool,
+    /// separator used between labels
+    pub(crate) separator: String,
+    /// optional domain suffix appended to computed host (e.g., ".svc.local")
+    pub(crate) domain_suffix: Option<String>,
+    /// label used when 0 kv pairs (global)
+    pub(crate) global_label: String,
+    /// default port for HTTP proxy upstream selection
+    pub(crate) http_port: u16,
+    /// default port for SOCKS5 proxy upstream selection
+    pub(crate) socks5_port: u16,
+    /// if true, only the base part before '+' is used for auth username
+    pub(crate) strip_suffix_for_auth: bool,
+}
+
+impl UsernameParamsToEscaperConfig {
+    pub(crate) fn new(position: Option<YamlDocPosition>) -> Self {
+        UsernameParamsToEscaperConfig {
+            position,
+            keys_for_host: Vec::new(),
+            require_hierarchy: true,
+            floating_keys: Vec::new(),
+            reject_unknown_keys: true,
+            reject_duplicate_keys: true,
+            separator: "-".to_string(),
+            domain_suffix: None,
+            global_label: "global".to_string(),
+            http_port: 10000,
+            socks5_port: 10001,
+            strip_suffix_for_auth: true,
+        }
+    }
+
+    pub(crate) fn parse(map: &yaml::Hash, position: Option<YamlDocPosition>) -> anyhow::Result<Self> {
+        let mut c = Self::new(position);
+        g3_yaml::foreach_kv(map, |k, v| c.set(k, v))?;
+        c.check()?;
+        Ok(c)
+    }
+
+    fn set(&mut self, k: &str, v: &Yaml) -> anyhow::Result<()> {
+        match g3_yaml::key::normalize(k).as_str() {
+            "keys_for_host" | "keys" => {
+                self.keys_for_host = g3_yaml::value::as_list(v, |v| g3_yaml::value::as_string(v))
+                    .context(format!("invalid string list value for key {k}"))?;
+                Ok(())
+            }
+            "require_hierarchy" => {
+                self.require_hierarchy = g3_yaml::value::as_bool(v)?;
+                Ok(())
+            }
+            "reject_unknown_keys" => {
+                self.reject_unknown_keys = g3_yaml::value::as_bool(v)?;
+                Ok(())
+            }
+            "floating_keys" | "floating" => {
+                self.floating_keys = g3_yaml::value::as_list(v, |v| g3_yaml::value::as_string(v))
+                    .context(format!("invalid string list value for key {k}"))?;
+                Ok(())
+            }
+            "reject_duplicate_keys" => {
+                self.reject_duplicate_keys = g3_yaml::value::as_bool(v)?;
+                Ok(())
+            }
+            "separator" => {
+                self.separator = g3_yaml::value::as_string(v)?;
+                Ok(())
+            }
+            "domain_suffix" | "suffix" => {
+                let mut s = g3_yaml::value::as_string(v)?;
+                if !s.is_empty() && !s.starts_with('.') {
+                    s.insert(0, '.');
+                }
+                self.domain_suffix = Some(s);
+                Ok(())
+            }
+            "global_label" => {
+                self.global_label = g3_yaml::value::as_string(v)?;
+                Ok(())
+            }
+            "http_port" => {
+                self.http_port = g3_yaml::value::as_u16(v)
+                    .context(format!("invalid u16 port value for key {k}"))?;
+                Ok(())
+            }
+            "socks5_port" | "socks_port" => {
+                self.socks5_port = g3_yaml::value::as_u16(v)
+                    .context(format!("invalid u16 port value for key {k}"))?;
+                Ok(())
+            }
+            "strip_suffix_for_auth" | "auth_strip_suffix" => {
+                self.strip_suffix_for_auth = g3_yaml::value::as_bool(v)?;
+                Ok(())
+            }
+            _ => Err(anyhow!("invalid key {k}")),
+        }
+    }
+
+    fn check(&mut self) -> anyhow::Result<()> {
+        if self.keys_for_host.iter().any(|k| k.is_empty()) {
+            return Err(anyhow!("keys_for_host contains empty key"));
+        }
+        if self.separator.is_empty() {
+            return Err(anyhow!("separator must not be empty"));
+        }
+        // ensure floating keys are included in keys_for_host
+        for fk in &self.floating_keys {
+            if !self.keys_for_host.iter().any(|k| k == fk) {
+                return Err(anyhow!("floating key {fk} must be listed in keys_for_host"));
+            }
+        }
+        Ok(())
+    }
+
+    pub(crate) fn suffix_for_host<'a>(&'a self, host: &'a str) -> Cow<'a, str> {
+        if let Some(sfx) = &self.domain_suffix {
+            if sfx.is_empty() {
+                Cow::Borrowed(host)
+            } else {
+                let mut s = String::with_capacity(host.len() + sfx.len());
+                s.push_str(host);
+                s.push_str(sfx);
+                Cow::Owned(s)
+            }
+        } else {
+            Cow::Borrowed(host)
+        }
+    }
+}

--- a/g3proxy/src/escape/divert_tcp/tcp_connect/mod.rs
+++ b/g3proxy/src/escape/divert_tcp/tcp_connect/mod.rs
@@ -306,7 +306,10 @@ impl DivertTcpEscaper {
         tcp_notes: &mut TcpConnectTaskNotes,
         task_notes: &ServerTaskNotes,
     ) -> Result<TcpStream, TcpConnectError> {
-        let peer_proxy = self.get_next_proxy(task_notes, task_conf.upstream.host());
+        let peer_proxy = task_notes
+            .override_next_proxy()
+            .cloned()
+            .unwrap_or_else(|| self.get_next_proxy(task_notes, task_conf.upstream.host()).clone());
 
         match peer_proxy.host() {
             Host::Ip(ip) => {

--- a/g3proxy/src/escape/proxy_http/tcp_connect/mod.rs
+++ b/g3proxy/src/escape/proxy_http/tcp_connect/mod.rs
@@ -302,7 +302,10 @@ impl ProxyHttpEscaper {
         tcp_notes: &mut TcpConnectTaskNotes,
         task_notes: &ServerTaskNotes,
     ) -> Result<TcpStream, TcpConnectError> {
-        let peer_proxy = self.get_next_proxy(task_notes, task_conf.upstream.host());
+        let peer_proxy = task_notes
+            .override_next_proxy()
+            .cloned()
+            .unwrap_or_else(|| self.get_next_proxy(task_notes, task_conf.upstream.host()).clone());
 
         match peer_proxy.host() {
             Host::Ip(ip) => {

--- a/g3proxy/src/escape/proxy_https/tcp_connect/mod.rs
+++ b/g3proxy/src/escape/proxy_https/tcp_connect/mod.rs
@@ -302,9 +302,10 @@ impl ProxyHttpsEscaper {
         tcp_notes: &mut TcpConnectTaskNotes,
         task_notes: &ServerTaskNotes,
     ) -> Result<(UpstreamAddr, TcpStream), TcpConnectError> {
-        let peer_proxy = self
-            .get_next_proxy(task_notes, task_conf.upstream.host())
-            .clone();
+        let peer_proxy = task_notes
+            .override_next_proxy()
+            .cloned()
+            .unwrap_or_else(|| self.get_next_proxy(task_notes, task_conf.upstream.host()).clone());
 
         let stream = match peer_proxy.host() {
             Host::Ip(ip) => {

--- a/g3proxy/src/escape/proxy_socks5/tcp_connect/mod.rs
+++ b/g3proxy/src/escape/proxy_socks5/tcp_connect/mod.rs
@@ -301,7 +301,10 @@ impl ProxySocks5Escaper {
         tcp_notes: &mut TcpConnectTaskNotes,
         task_notes: &ServerTaskNotes,
     ) -> Result<TcpStream, TcpConnectError> {
-        let peer_proxy = self.get_next_proxy(task_notes, task_conf.upstream.host());
+        let peer_proxy = task_notes
+            .override_next_proxy()
+            .cloned()
+            .unwrap_or_else(|| self.get_next_proxy(task_notes, task_conf.upstream.host()).clone());
 
         match peer_proxy.host() {
             Host::Ip(ip) => {

--- a/g3proxy/src/escape/proxy_socks5s/tcp_connect/mod.rs
+++ b/g3proxy/src/escape/proxy_socks5s/tcp_connect/mod.rs
@@ -301,9 +301,10 @@ impl ProxySocks5sEscaper {
         tcp_notes: &mut TcpConnectTaskNotes,
         task_notes: &ServerTaskNotes,
     ) -> Result<(UpstreamAddr, TcpStream), TcpConnectError> {
-        let peer_proxy = self
-            .get_next_proxy(task_notes, task_conf.upstream.host())
-            .clone();
+        let peer_proxy = task_notes
+            .override_next_proxy()
+            .cloned()
+            .unwrap_or_else(|| self.get_next_proxy(task_notes, task_conf.upstream.host()).clone());
 
         let stream = match peer_proxy.host() {
             Host::Ip(ip) => {

--- a/g3proxy/src/serve/mod.rs
+++ b/g3proxy/src/serve/mod.rs
@@ -52,6 +52,7 @@ mod tls_stream;
 
 mod error;
 mod task;
+mod username_params;
 
 pub(crate) use error::{ServerTaskError, ServerTaskForbiddenError, ServerTaskResult};
 pub(crate) use task::{ServerTaskNotes, ServerTaskStage};

--- a/g3proxy/src/serve/socks_proxy/task/negotiation/task.rs
+++ b/g3proxy/src/serve/socks_proxy/task/negotiation/task.rs
@@ -11,6 +11,7 @@ use tokio::time::Instant;
 
 use g3_io_ext::{AsyncStream, LimitedReader, LimitedWriter};
 use g3_socks::{SocksAuthMethod, SocksCommand, SocksVersion, v4a, v5};
+use g3_types::auth::Username;
 
 use super::tcp_connect::SocksProxyTcpConnectTask;
 use super::udp_associate::SocksProxyUdpAssociateTask;
@@ -211,6 +212,7 @@ impl SocksProxyNegotiationTask {
             .await
             .map_err(ServerTaskError::ClientTcpWriteFailed)?;
 
+        let mut username_for_mapping: Option<String> = None;
         let user_ctx = match auth_method {
             SocksAuthMethod::None => {
                 if let Some(user_group) = &self.user_group {
@@ -232,8 +234,23 @@ impl SocksProxyNegotiationTask {
             SocksAuthMethod::User => {
                 if let Some(user_group) = &self.user_group {
                     let (username, password) = v5::auth::recv_user_from_client(&mut clt_r).await?;
+                    // preserve original username for mapping
+                    let username_original = username.as_original().to_string();
+                    // optionally strip suffix for auth
+                    let mut base_username: Option<Username> = None;
+                    if let Some(cfg) = &self.ctx.server_config.username_params_to_escaper_addr {
+                        if cfg.strip_suffix_for_auth {
+                            let base = crate::serve::username_params::ParsedUsernameParams::auth_base(
+                                &username_original,
+                            );
+                            if base != username_original {
+                                base_username = Username::from_original(base).ok();
+                            }
+                        }
+                    }
+                    let username_ref = base_username.as_ref().unwrap_or(&username);
                     match user_group.check_user_with_password(
-                        &username,
+                        username_ref,
                         &password,
                         self.ctx.server_config.name(),
                         self.ctx.server_stats.share_extra_tags(),
@@ -248,6 +265,8 @@ impl SocksProxyNegotiationTask {
                             v5::auth::send_user_auth_success(&mut clt_w)
                                 .await
                                 .map_err(ServerTaskError::ClientTcpWriteFailed)?;
+                            // store original username for later mapping
+                            username_for_mapping = Some(username_original);
                             Some(user_ctx)
                         }
                         Err(e) => {
@@ -274,11 +293,42 @@ impl SocksProxyNegotiationTask {
 
         let req = v5::Socks5Request::recv(&mut clt_r).await?;
 
-        let task_notes = ServerTaskNotes::new(
+        // compute mapping after auth success but before task creation; deny on error
+        let mut override_next: Option<g3_types::net::UpstreamAddr> = None;
+        if let Some(cfg) = &self.ctx.server_config.username_params_to_escaper_addr {
+            if let Some(name) = &username_for_mapping {
+                match crate::serve::username_params::compute_upstream_from_username(
+                    cfg,
+                    name,
+                    crate::serve::username_params::InboundKind::Socks5,
+                ) {
+                    Ok(a) => override_next = Some(a),
+                    Err(_e) => {
+                        let _ = v5::Socks5Reply::ForbiddenByRule.send(&mut clt_w).await;
+                        return Err(ServerTaskError::ForbiddenByRule(
+                            ServerTaskForbiddenError::DestDenied,
+                        ));
+                    }
+                }
+            }
+        }
+
+        let mut task_notes = ServerTaskNotes::new(
             self.ctx.cc_info.clone(),
             user_ctx,
             self.time_accepted.elapsed(),
         );
+        if let Some(a) = override_next.take() {
+            task_notes.set_override_next_proxy(a);
+            debug!(
+                "[{}] socks username params -> next proxy {}",
+                self.ctx.server_config.name(),
+                task_notes
+                    .override_next_proxy()
+                    .map(|a| a.to_string())
+                    .unwrap_or_else(|| "<none>".into())
+            );
+        }
         match req.command {
             SocksCommand::TcpConnect => {
                 let task = SocksProxyTcpConnectTask::new(

--- a/g3proxy/src/serve/socks_proxy/task/tcp_connect/task.rs
+++ b/g3proxy/src/serve/socks_proxy/task/tcp_connect/task.rs
@@ -489,9 +489,8 @@ impl StreamTransitTask for SocksProxyTcpConnectTask {
     }
 
     fn log_client_shutdown(&self) {
-        if let Some(log_ctx) = self.get_log_context() {
-            log_ctx.log_client_shutdown();
-        }
+        // Intentionally no-op to avoid duplicate INFO lines.
+        // We emit a single final Finished log for this task, matching HTTP behavior.
     }
 
     fn log_upstream_shutdown(&self) {

--- a/g3proxy/src/serve/username_params.rs
+++ b/g3proxy/src/serve/username_params.rs
@@ -1,0 +1,340 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright 2025 ByteDance and/or its affiliates.
+ */
+
+use std::collections::HashMap;
+
+use anyhow::anyhow;
+use log::debug;
+
+use g3_types::net::UpstreamAddr;
+
+use crate::config::server::username_params_to_escaper::UsernameParamsToEscaperConfig;
+
+#[derive(Debug, Clone)]
+pub(crate) struct ParsedUsernameParams {
+    pub(crate) base: String,
+    pub(crate) params: HashMap<String, String>,
+}
+
+impl ParsedUsernameParams {
+    pub(crate) fn parse(original: &str) -> anyhow::Result<Self> {
+        // expected format: base[+key=value]*, keys/values are non-empty, no escaping
+        let mut it = original.split('+');
+        let base = it
+            .next()
+            .ok_or_else(|| anyhow!("empty username"))?
+            .to_string();
+        let mut params = HashMap::new();
+        for t in it {
+            let mut kv = t.splitn(2, '=');
+            let k = kv
+                .next()
+                .ok_or_else(|| anyhow!("invalid token: missing key"))?;
+            let v = kv
+                .next()
+                .ok_or_else(|| anyhow!("invalid token: missing value for key {k}"))?;
+            if k.is_empty() || v.is_empty() {
+                return Err(anyhow!("empty key or value in username params"));
+            }
+            if params.contains_key(k) {
+                return Err(anyhow!("duplicate key {k}"));
+            }
+            params.insert(k.to_string(), v.to_string());
+        }
+        Ok(ParsedUsernameParams { base, params })
+    }
+
+    pub(crate) fn auth_base(original: &str) -> &str {
+        // return substring before first '+'
+        if let Some((base, _)) = original.split_once('+') {
+            base
+        } else {
+            original
+        }
+    }
+}
+
+#[derive(Copy, Clone, Debug)]
+pub(crate) enum InboundKind {
+    Http,
+    Socks5,
+}
+
+pub(crate) fn compute_upstream_from_username(
+    cfg: &UsernameParamsToEscaperConfig,
+    username_original: &str,
+    inbound: InboundKind,
+) -> anyhow::Result<UpstreamAddr> {
+    debug!(
+        "username-params: inbound={:?} original='{}'",
+        inbound, username_original
+    );
+    let parsed = ParsedUsernameParams::parse(username_original)?;
+    debug!(
+        "username-params: base='{}' params={:?}",
+        parsed.base, parsed.params
+    );
+
+    // validate keys
+    if cfg.reject_unknown_keys {
+        for k in parsed.params.keys() {
+            if !cfg.keys_for_host.iter().any(|x| x == k) {
+                debug!("username-params: reject unknown key '{}'", k);
+                return Err(anyhow!("unknown key {k}"));
+            }
+        }
+    }
+
+    if cfg.require_hierarchy {
+        // if a later non-floating key appears, all earlier non-floating must be present
+        let mut saw_missing_required = false;
+        for key in &cfg.keys_for_host {
+            let is_floating = cfg.floating_keys.iter().any(|k| k == key);
+            match parsed.params.get(key) {
+                Some(_v) => {
+                    if saw_missing_required && !is_floating {
+                        debug!(
+                            "username-params: hierarchy violation at key '{}' (floating={})",
+                            key, is_floating
+                        );
+                        return Err(anyhow!(
+                            "key {key} requires its ancestor keys to be present"
+                        ));
+                    }
+                }
+                None => {
+                    if !is_floating {
+                        // mark that following present required keys will violate hierarchy
+                        saw_missing_required = true;
+                    }
+                }
+            }
+        }
+    }
+
+    // build host label sequence in configured order, skipping missing keys
+    let mut parts: Vec<&str> = Vec::new();
+    for k in &cfg.keys_for_host {
+        if let Some(v) = parsed.params.get(k) {
+            parts.push(v);
+        }
+    }
+    debug!(
+        "username-params: keys_for_host={:?} floating_keys={:?} used_parts={:?}",
+        cfg.keys_for_host, cfg.floating_keys, parts
+    );
+
+    let port = match inbound {
+        InboundKind::Http => cfg.http_port,
+        InboundKind::Socks5 => cfg.socks5_port,
+    };
+
+    // Build label or use global
+    let label = if parts.is_empty() {
+        debug!("username-params: no parts, using global_label='{}'", cfg.global_label);
+        cfg.global_label.clone()
+    } else {
+        // join with the configured separator
+        let mut s = String::new();
+        for (i, v) in parts.iter().enumerate() {
+            if i > 0 {
+                s.push_str(&cfg.separator);
+            }
+            s.push_str(v);
+        }
+        debug!("username-params: joined label='{}' separator='{}'", s, cfg.separator);
+        s
+    };
+
+    // Apply optional suffix
+    let full_host_cow = cfg.suffix_for_host(&label);
+    let full_host = full_host_cow.as_ref();
+    if !matches!(full_host_cow, std::borrow::Cow::Borrowed(_)) {
+        debug!(
+            "username-params: apply domain_suffix -> host='{}'",
+            full_host
+        );
+    } else {
+        debug!("username-params: no domain_suffix -> host='{}'", full_host);
+    }
+    debug!("username-params: chosen port={} from inbound={:?}", port, inbound);
+
+    // RFC 6761: names in the .localhost domain resolve to loopback.
+    // Honor this locally to avoid relying on external DNS servers.
+    if full_host.eq_ignore_ascii_case("localhost")
+        || full_host.to_ascii_lowercase().ends_with(".localhost")
+    {
+        debug!(
+            "username-params: mapping '{}' to 127.0.0.1 due to .localhost",
+            full_host
+        );
+        return Ok(UpstreamAddr::from_host_str_and_port("127.0.0.1", port)?);
+    }
+
+    debug!(
+        "username-params: final next-hop host='{}' port={}",
+        full_host, port
+    );
+    Ok(UpstreamAddr::from_host_str_and_port(full_host, port)?)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use g3_types::net::Host;
+
+    fn cfg_with_keys(keys: &[&str]) -> UsernameParamsToEscaperConfig {
+        let mut c = UsernameParamsToEscaperConfig::new(None);
+        c.keys_for_host = keys.iter().map(|s| s.to_string()).collect();
+        c.require_hierarchy = true;
+        c.reject_unknown_keys = true;
+        c.floating_keys = Vec::new();
+        c.global_label = "global".to_string();
+        c.http_port = 10000;
+        c.socks5_port = 10001;
+        c
+    }
+
+    #[test]
+    fn auth_base_works() {
+        assert_eq!(ParsedUsernameParams::auth_base("user"), "user");
+        assert_eq!(ParsedUsernameParams::auth_base("user+label1=foo"), "user");
+        assert_eq!(ParsedUsernameParams::auth_base("u+key=v+z=t"), "u");
+    }
+
+    #[test]
+    fn parse_valid_and_duplicate() {
+        let p = ParsedUsernameParams::parse("user+label1=foo+label2=bar").unwrap();
+        assert_eq!(p.base, "user");
+        assert_eq!(p.params.get("label1").unwrap(), "foo");
+        assert_eq!(p.params.get("label2").unwrap(), "bar");
+
+        // duplicate key should error
+        assert!(ParsedUsernameParams::parse("user+label1=foo+label1=baz").is_err());
+    }
+
+    #[test]
+    fn compute_global_defaults() {
+        let cfg = cfg_with_keys(&["label1", "label2", "label3", "label4"]);
+        let ups = compute_upstream_from_username(&cfg, "user", InboundKind::Http).unwrap();
+        assert_eq!(ups.port(), 10000);
+        match ups.host() {
+            Host::Domain(d) => assert_eq!(d.as_ref(), "global"),
+            _ => panic!("expected domain host"),
+        }
+    }
+
+    #[test]
+    fn compute_join_and_ports() {
+        let cfg = cfg_with_keys(&["label1", "label2", "label3"]);
+        let ups = compute_upstream_from_username(
+            &cfg,
+            "user+label1=foo+label2=bar",
+            InboundKind::Http,
+        )
+        .unwrap();
+        assert_eq!(ups.port(), 10000);
+        match ups.host() {
+            Host::Domain(d) => assert_eq!(d.as_ref(), "foo-bar"),
+            _ => panic!("expected domain host"),
+        }
+
+        let ups2 = compute_upstream_from_username(
+            &cfg,
+            "user+label1=foo+label2=bar",
+            InboundKind::Socks5,
+        )
+        .unwrap();
+        assert_eq!(ups2.port(), 10001);
+    }
+
+    #[test]
+    fn compute_unknown_and_hierarchy() {
+        let mut cfg = cfg_with_keys(&["label1", "label2"]);
+        // unknown keys rejected
+        assert!(compute_upstream_from_username(&cfg, "user+x=y", InboundKind::Http).is_err());
+
+        // allow unknown keys when disabled
+        cfg.reject_unknown_keys = false;
+        let ups = compute_upstream_from_username(&cfg, "user+x=y", InboundKind::Http).unwrap();
+        match ups.host() {
+            Host::Domain(d) => assert_eq!(d.as_ref(), "global"),
+            _ => panic!("expected domain host"),
+        }
+
+        // hierarchy enforced: region without country should error
+        cfg.reject_unknown_keys = true;
+        cfg.require_hierarchy = true;
+        assert!(compute_upstream_from_username(&cfg, "user+label2=b", InboundKind::Http).is_err());
+
+        // disable hierarchy and allow trailing keys
+        cfg.require_hierarchy = false;
+        let ups2 = compute_upstream_from_username(&cfg, "user+label2=b", InboundKind::Http)
+            .unwrap();
+        match ups2.host() {
+            Host::Domain(d) => assert_eq!(d.as_ref(), "b"),
+            _ => panic!("expected domain host"),
+        }
+    }
+
+    #[test]
+    fn compute_with_suffix() {
+        let mut cfg = cfg_with_keys(&["label1"]);
+        cfg.domain_suffix = Some(".svc.local".to_string());
+        let ups =
+            compute_upstream_from_username(&cfg, "user+label1=foo", InboundKind::Http).unwrap();
+        match ups.host() {
+            Host::Domain(d) => assert_eq!(d.as_ref(), "foo.svc.local"),
+            _ => panic!("expected domain host"),
+        }
+    }
+
+    #[test]
+    fn compute_with_floating_optional() {
+        // label order: label1, label2, label3, label4, opt; opt is floating (independent)
+        let mut cfg = cfg_with_keys(&["label1", "label2", "label3", "label4", "opt"]);
+        cfg.floating_keys = vec!["opt".to_string()];
+
+        // opt only
+        let ups = compute_upstream_from_username(&cfg, "user+opt=o123", InboundKind::Http)
+            .unwrap();
+        match ups.host() {
+            Host::Domain(d) => assert_eq!(d.as_ref(), "o123"),
+            _ => panic!("expected domain host"),
+        }
+
+        // label1 + opt
+        let ups = compute_upstream_from_username(
+            &cfg,
+            "user+label1=foo+opt=o123",
+            InboundKind::Http,
+        )
+        .unwrap();
+        match ups.host() {
+            Host::Domain(d) => assert_eq!(d.as_ref(), "foo-o123"),
+            _ => panic!("expected domain host"),
+        }
+
+        // full hierarchy + opt
+        let ups = compute_upstream_from_username(
+            &cfg,
+            "user+label1=foo+label2=bar+label3=baz+label4=qux+opt=o123",
+            InboundKind::Http,
+        )
+        .unwrap();
+        match ups.host() {
+            Host::Domain(d) => assert_eq!(d.as_ref(), "foo-bar-baz-qux-o123"),
+            _ => panic!("expected domain host"),
+        }
+
+        // label2 without label1 (still invalid), even if opt present
+        assert!(compute_upstream_from_username(
+            &cfg,
+            "user+label2=bar+opt=o123",
+            InboundKind::Http,
+        )
+        .is_err());
+    }
+}


### PR DESCRIPTION
aka derive next-hop escaper address from proxy username params (HTTP & SOCKS5).

- Adds an opt-in feature to compute chained next-hop host:port from proxy username parameters for HTTP and SOCKS5
servers.
- Supports hierarchical labels with optional “floating” keys (e.g., a key that can appear independently and also append
at the end of a hierarchy).
- Provides detailed -vvv debug logs for derivation; maintains INFO-level behavior parity between HTTP and SOCKS.
- Updates examples and docs (EN + ZH) with clear configuration and usage.

Motivation

- Avoid predefining all possible services; compute them dynamically from username params.
- Preserve local auth semantics while decoupling routing from user identity.
- Provide strong observability for troubleshooting (derivation steps visible at -vvv).

Config Schema (per-server)

- keys_for_host: ordered list of keys used to construct the host label.
- floating_keys: keys that may appear independently and do not require earlier non-floating keys.
- require_hierarchy: enforce order for non-floating keys (child requires parent).
- reject_unknown_keys, reject_duplicate_keys: validation policy.
- separator: delimiter to join values.
- domain_suffix: optional suffix appended to the computed host (e.g., “.svc.cluster.local”); empty means literal host.
- global_label: label used when no key-value pairs present.
- http_port, socks5_port: default next-hop ports selected by inbound protocol.
- strip_suffix_for_auth: use only the base (before ‘+’) for local user auth.

Behavior

- Host derivation: join values of supplied keys (in keys_for_host order) with separator. If none supplied -> global_label.
- Floating keys:
    - Must be listed in both keys_for_host and floating_keys.
    - Can appear alone and don’t require earlier non-floating keys.
    - Don’t relax hierarchy for non-floating keys that follow.
    - Appended exactly once at their position in keys_for_host if present.
- Port selection: inbound protocol chooses http_port (HTTP) or socks5_port (SOCKS5).
- DNS:
    - For .localhost suffixes, resolves to 127.0.0.1 without external DNS (RFC 6761) to make local demos robust.
    - For Kubernetes, set domain_suffix to a fully-qualified cluster suffix (e.g., “.default.svc.cluster.local”) or
ensure the service name resolves in the proxy pod’s namespace/search path.
- HTTP invalid params: returns 400 Bad Request (unknown keys, hierarchy violations).
- SOCKS5 invalid params: sends standard error reply and denies the request.
- Credentials: client username/password are used only for local auth. They are not forwarded upstream. Upstream auth
(if any) is configured on the escaper.

Implementation

- Config: src/config/server/username_params_to_escaper.rs (adds floating_keys; schema parsing + validation).
- Parser/compute: src/serve/username_params.rs
    - Parses base+key=value+..., enforces policy, builds label, applies suffix, selects port.
    - -vvv debug logs show: inbound, original, parsed params, keys used, label, suffix, port, final host:port.
- HTTP integration: src/serve/http_proxy/task/pipeline/writer.rs
    - Optional auth base stripping; computes next-hop from username; sets per-connection override; 400 on invalid
params.
- SOCKS5 integration: src/serve/socks_proxy/task/negotiation/task.rs
    - Optional auth base stripping; computes next-hop after auth; sets per-connection override; standard error on
invalid params.
- Connection override: src/serve/task.rs adds per-connection override_next_proxy (consumed in proxy connect paths).
- Escaper usage: connection builders for proxy_http / proxy_https / proxy_socks5 / proxy_socks5s / divert_tcp read the
override and use it for that attempt (no API changes in escapers).
- Logging: suppressed duplicate SOCKS “ClientShutdown” INFO event to match HTTP’s single INFO (Finished). Otherwise no
INFO changes.

Examples & Docs

- Example: examples/username-params-escaper/g3proxy.yaml
    - Shows keys_for_host + floating_keys, notes that proxy_addr is required by escapers but is overridden per
connection when username params are present; guidance for setting meaningful fallbacks if desired.
- Docs:
    - UserGuide.en_US.md + UserGuide.zh_CN.md: “Username Params -> Next-Hop Escaper” sections added (config, behavior,
validation, fallback note).
    - Kubernetes note: recommend using fully-qualified domain_suffix when resolving Services across namespaces.

Compatibility

- Opt-in only: no behavior change unless username_params_to_escaper_addr is configured.
- Logging parity: HTTP and SOCKS both emit a single INFO line per request by default.
- Existing escapers and servers unaffected.

Testing

- Unit tests (src/serve/username_params.rs): 24 tests cover parsing, ordering, hierarchy, floating keys, suffix
application, and port selection.
- Local demo: with domain_suffix “.localhost”, labels resolve to loopback without external DNS.
- Kubernetes: works with FQDN suffix (e.g., “.default.svc.cluster.local”); otherwise ensure namespace/search path resolves short names.

Notes

- proxy_addr placeholders exist to satisfy escaper init; when username params are present and valid, the per-connection override bypasses proxy_addr. Set proxy_addr to a real default next hop only if you want a fallback for requests that don’t provide username params.
- strip_suffix_for_auth affects local auth username only; client password is never forwarded to the upstream proxy.

If maintainers prefer, I can:

- Gate the .localhost-to-loopback mapping behind a config flag (currently always applied to assist local examples).
- Make the SOCKS partial-shutdown event available at debug level rather than suppressing it entirely.

Take it for a spin
Prerequisites 
Have http and socks5 proxies listening on ports 10000, 10001 respectively. 

Run it
(assuming g3proxy dir)
cargo run -p g3proxy -- -vvv -c examples/username-params-escaper/g3proxy.yaml

In another terminal:
HTTP example
curl -x http://user:foobar@127.0.0.1:13128 [ipinfo.io](http://ipinfo.io/)
Forwards to a “global” http proxy (can be anything)

SOCKS5 example
curl --socks5-hostname user:foobar@127.0.0.1:11080 [ipinfo.io](http://ipinfo.io/)
Fwds to global socks5 proxy 

curl -x http://user+label1=foo+opt=bar:password@127.0.0.1:13128 [ipinfo.io](http://ipinfo.io/)
-> foo-bar.localhost

curl -x http://user+label2=foo:password@127.0.0.1:13128 [ipinfo.io](http://ipinfo.io/)
-> 400 Bad Request due to using label2 without label1