### PR TITLE
feat(proxy): Redis-backed sticky sessions for HTTP/SOCKS with HRW selection, sliding TTL, HTTP DX headers, and example env

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1931,6 +1931,7 @@ dependencies = [
  "g3proxy-proto",
  "h2",
  "http",
+ "humantime",
  "indexmap",
  "ip_network",
  "ip_network_table",
@@ -2351,6 +2352,12 @@ name = "humanize-rs"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "016b02deb8b0c415d8d56a6f0ab265e50c22df61194e37f9be75ed3a722de8a6"
+
+[[package]]
+name = "humantime"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b112acc8b3adf4b107a8ec20977da0273a8c386765a3ec0229bd500a1443f9f"
 
 [[package]]
 name = "iana-time-zone"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1942,6 +1942,7 @@ dependencies = [
  "memchr",
  "mime",
  "mlua",
+ "once_cell",
  "openssl-probe",
  "percent-encoding",
  "pin-project-lite",

--- a/g3proxy/Cargo.toml
+++ b/g3proxy/Cargo.toml
@@ -48,6 +48,7 @@ capnp-rpc.workspace = true
 capnp.workspace = true
 itoa.workspace = true
 redis = { workspace = true, features = ["aio", "tokio-comp"] }
+humantime = "2.1"
 ascii.workspace = true
 ahash.workspace = true
 foldhash.workspace = true
@@ -60,7 +61,7 @@ kanal = { workspace = true, features = ["async"] }
 lru.workspace = true
 regex.workspace = true
 mlua = { workspace = true, features = ["send"], optional = true }
-pyo3 = { workspace = true, features = ["auto-initialize"], optional = true }
+pyo3 = { workspace = true, optional = true }
 g3-cert-agent = { workspace = true, features = ["yaml"] }
 g3-daemon = { workspace = true, features = ["event-log"] }
 g3-datetime.workspace = true

--- a/g3proxy/Cargo.toml
+++ b/g3proxy/Cargo.toml
@@ -47,6 +47,7 @@ arc-swap.workspace = true
 capnp-rpc.workspace = true
 capnp.workspace = true
 itoa.workspace = true
+once_cell.workspace = true
 redis = { workspace = true, features = ["aio", "tokio-comp"] }
 humantime = "2.1"
 ascii.workspace = true

--- a/g3proxy/UserGuide.en_US.md
+++ b/g3proxy/UserGuide.en_US.md
@@ -334,6 +334,47 @@ escaper:
     tls_name: example.com # If the proxy address does not contain a domain name, and you need to verify the certificate with DNS Name, you need to set it
 ```
 
+#### Username Params → Next-Hop Escaper
+
+For HTTP and SOCKS5 proxy servers, you can derive the chained next-hop address from the client username by appending
+ordered key-value pairs after the base name: `base+key1=val1+key2=val2+...`.
+
+- Enable per server with `username_params_to_escaper_addr`.
+- The host is built by joining configured keys’ values using a separator; with no keys, a `global_label` is used.
+- The port is selected based on inbound protocol (HTTP/SOCKS5), both configurable.
+- Unknown keys and hierarchy violations (e.g., child without parent) can be rejected.
+
+Example configuration:
+
+```yaml
+server:
+  - name: http-in
+    type: http_proxy
+    escaper: chain
+    username_params_to_escaper_addr:
+      keys_for_host: [label1, label2, label3]
+      require_hierarchy: true
+      reject_unknown_keys: true
+      reject_duplicate_keys: true
+      separator: "-"
+      # Optional suffix (e.g., for local testing):
+      # domain_suffix: ".localhost"
+      global_label: "global"
+      http_port: 10000
+      socks5_port: 10001
+      strip_suffix_for_auth: true
+```
+
+Behavior:
+- Username `user+label1=foo+label2=bar` → host `foo-bar`, port `10000` for HTTP inbound.
+- Invalid params cause HTTP 400 Bad Request; SOCKS5 replies with a standard error code and denies the request.
+
+Escaper fallback note:
+- Proxy chaining escapers (proxy_http/proxy_socks5/…) must define at least one `proxy_addr` to initialize.
+- When username params are present (and auth succeeds), the computed host:port overrides `proxy_addr` for that connection.
+- If you want a real fallback for requests without username params (e.g., anonymous), set `proxy_addr` to your default next‑hop
+  (for this example: HTTP → 127.0.0.1:10000, SOCKS5 → 127.0.0.1:10001). Otherwise the placeholder values are never used.
+
 ### Connection Throttling
 
 All servers, escapers, users support per-connection throttling. Set the same key in the corresponding server &

--- a/g3proxy/UserGuide.en_US.md
+++ b/g3proxy/UserGuide.en_US.md
@@ -47,6 +47,7 @@
 - [Scenario Design](#scenario-design)
     + [Multi-Region Acceleration](#multi-region-acceleration)
     + [Dual Exit Disaster Recovery](#dual-exit-disaster-recovery)
+- [Sticky Sessions](#sticky-sessions)
 
 ## Installation
 

--- a/g3proxy/UserGuide.en_US.md
+++ b/g3proxy/UserGuide.en_US.md
@@ -1119,21 +1119,23 @@ Each node's Proxy is configured with the following functions:
   - Works with HTTP Basic (Proxy-Authorization) and SOCKS5 username.
 - Behavior:
   - `sticky`: sliding TTL (default 60s) refreshed after each successful request.
-  - `session_id`: optional correlation key; sticky is active with or without it. change it to get a different random upstream programmatically.
+  - `session_id`: optional correlation key; when sticky is globally enabled, stickiness applies with or without it. Change it to get a different upstream deterministically.
   - `rotate=1`: overrides and disables sticky.
   - Stickiness is implemented via HRW (rendezvous hashing) across current A records and shared via Redis.
   - Keying: `prefix:host:port|<base_user>[|<canonical_params>]` where `<canonical_params>` is the sorted unknown params plus `session_id` when provided; `sticky`/`rotate` are not part of the key.
-- Response headers (HTTP):
-  - `X-Sticky-Session: on|off`
-  - `X-Sticky-Expires-At: <RFC3339 timestamp>` (present when `on`).
-  - Logs include a non-reversible hash of the sticky key (not the raw key) for privacy.
-- Config:
+  - Response headers (HTTP):
+    - `X-Sticky-Session: on|off`
+    - `X-Sticky-Expires-At: <RFC3339 timestamp>` (present when `on`).
+    - Logs include a non-reversible hash of the sticky key (not the raw key) for privacy.
+- Config (opt-in):
   - Global (only) in main YAML:
     ```yaml
     sticky:
+      enabled: true            # REQUIRED to enable stickiness (default: false)
       url: redis://redis.default.svc.cluster.local:6379/0
       prefix: g3proxy:sticky
       default_ttl: 60s
       max_ttl: 1h
     ```
-    Per-server overrides are not supported; sticky settings are process-global.
+    - If `enabled` is omitted or false, stickiness is disabled regardless of username modifiers.
+    - Per-server overrides are not supported; sticky settings are process-global.

--- a/g3proxy/UserGuide.en_US.md
+++ b/g3proxy/UserGuide.en_US.md
@@ -1108,3 +1108,31 @@ Each node's Proxy is configured with the following functions:
       tls_client: {} # Configure TLS parameters
       # ... Configure proxy parameters to the relay proxy address in the POP2 region
   ```
+# Sticky Sessions
+
+- Username modifiers: use `+` to add params to the base username.
+  - Examples:
+    - `user+sticky=60s+session_id=abc123`
+    - `user+session_id=cart42`
+    - `user+rotate=1` (disables stickiness)
+  - Works with HTTP Basic (Proxy-Authorization) and SOCKS5 username.
+- Behavior:
+  - `sticky`: sliding TTL (default 60s) refreshed after each successful request.
+  - `session_id`: optional correlation key; sticky is active with or without it. change it to get a different random upstream programmatically.
+  - `rotate=1`: overrides and disables sticky.
+  - Stickiness is implemented via HRW (rendezvous hashing) across current A records and shared via Redis.
+  - Keying: `prefix:host:port|<base_user>[|<canonical_params>]` where `<canonical_params>` is the sorted unknown params plus `session_id` when provided; `sticky`/`rotate` are not part of the key.
+- Response headers (HTTP):
+  - `X-Sticky-Session: on|off`
+  - `X-Sticky-Expires-At: <RFC3339 timestamp>` (present when `on`).
+  - Logs include a non-reversible hash of the sticky key (not the raw key) for privacy.
+- Config:
+  - Global (only) in main YAML:
+    ```yaml
+    sticky:
+      url: redis://redis.default.svc.cluster.local:6379/0
+      prefix: g3proxy:sticky
+      default_ttl: 60s
+      max_ttl: 1h
+    ```
+    Per-server overrides are not supported; sticky settings are process-global.

--- a/g3proxy/UserGuide.en_US.md
+++ b/g3proxy/UserGuide.en_US.md
@@ -340,7 +340,7 @@ For HTTP and SOCKS5 proxy servers, you can derive the chained next-hop address f
 ordered key-value pairs after the base name: `base+key1=val1+key2=val2+...`.
 
 - Enable per server with `username_params_to_escaper_addr`.
-- The host is built by joining configured keys’ values using a separator; with no keys, a `global_label` is used.
+- The host is built by joining configured keys’ values using a separator; if no recognized keys are present, no override is applied and the escaper’s default `proxy_addr` is used.
 - The port is selected based on inbound protocol (HTTP/SOCKS5), both configurable.
 - Unknown keys and hierarchy violations (e.g., child without parent) can be rejected.
 
@@ -359,7 +359,6 @@ server:
       separator: "-"
       # Optional suffix (e.g., for local testing):
       # domain_suffix: ".localhost"
-      global_label: "global"
       http_port: 10000
       socks5_port: 10001
       strip_suffix_for_auth: true
@@ -367,13 +366,13 @@ server:
 
 Behavior:
 - Username `user+label1=foo+label2=bar` → host `foo-bar`, port `10000` for HTTP inbound.
+- If no recognized keys are present, no override is applied (the escaper’s `proxy_addr` acts as fallback).
 - Invalid params cause HTTP 400 Bad Request; SOCKS5 replies with a standard error code and denies the request.
 
 Escaper fallback note:
 - Proxy chaining escapers (proxy_http/proxy_socks5/…) must define at least one `proxy_addr` to initialize.
 - When username params are present (and auth succeeds), the computed host:port overrides `proxy_addr` for that connection.
-- If you want a real fallback for requests without username params (e.g., anonymous), set `proxy_addr` to your default next‑hop
-  (for this example: HTTP → 127.0.0.1:10000, SOCKS5 → 127.0.0.1:10001). Otherwise the placeholder values are never used.
+- When no recognized keys are present in the username, no override is applied; the configured `proxy_addr` is used.
 
 ### Connection Throttling
 

--- a/g3proxy/UserGuide.zh_CN.md
+++ b/g3proxy/UserGuide.zh_CN.md
@@ -312,6 +312,46 @@ escaper:
     tls_name: example.com # 代理地址不包含域名时，如果需要用DNS Name验证证书，则需要设置
 ```
 
+#### 用户名参数 → 串联下一跳地址
+
+对于 HTTP 和 SOCKS5 代理入口，可以通过在用户名后追加有序的键值对，动态计算串联下一跳的地址：`base+key1=val1+key2=val2+...`。
+
+- 在对应入口下启用 `username_params_to_escaper_addr` 即可生效。
+- 计算主机名：按配置的键顺序取值并用分隔符拼接；未提供键值时使用 `global_label`。
+- 端口：根据入站协议选择（HTTP / SOCKS5），均可配置。
+- 可配置是否拒绝未知键、是否强制层级（例如子键必须有父键）。
+
+示例配置：
+
+```yaml
+server:
+  - name: http-in
+    type: http_proxy
+    escaper: chain
+    username_params_to_escaper_addr:
+      keys_for_host: [label1, label2, label3]
+      require_hierarchy: true
+      reject_unknown_keys: true
+      reject_duplicate_keys: true
+      separator: "-"
+      # 可选后缀（例如本地测试）：
+      # domain_suffix: ".localhost"
+      global_label: "global"
+      http_port: 10000
+      socks5_port: 10001
+      strip_suffix_for_auth: true
+```
+
+行为说明：
+- 用户名 `user+label1=foo+label2=bar` → 主机 `foo-bar`，HTTP 入站端口 `10000`。
+- 非法参数（未知键或层级违例）会导致 HTTP 返回 400 Bad Request；SOCKS5 返回标准错误码并拒绝请求。
+
+出口回退说明：
+- 代理串联出口（proxy_http / proxy_socks5 / …）在初始化时必须配置至少一个 `proxy_addr`。
+- 当用户名参数存在且认证成功时，计算得到的 host:port 会覆盖该连接的 `proxy_addr`。
+- 如果希望对“未提供用户名参数”的请求提供真实回退路径（例如允许匿名），请将 `proxy_addr` 设置为默认下一跳
+  （本示例可用：HTTP → 127.0.0.1:10000，SOCKS5 → 127.0.0.1:10001）。否则示例中的占位值不会被使用。
+
 ### 连接限速
 
 server、escaper、user维度均支持设置单连接限速，配置key相同，在对应的server & escaper & user里设置：

--- a/g3proxy/UserGuide.zh_CN.md
+++ b/g3proxy/UserGuide.zh_CN.md
@@ -317,7 +317,7 @@ escaper:
 对于 HTTP 和 SOCKS5 代理入口，可以通过在用户名后追加有序的键值对，动态计算串联下一跳的地址：`base+key1=val1+key2=val2+...`。
 
 - 在对应入口下启用 `username_params_to_escaper_addr` 即可生效。
-- 计算主机名：按配置的键顺序取值并用分隔符拼接；未提供键值时使用 `global_label`。
+- 计算主机名：按配置的键顺序取值并用分隔符拼接；若用户名中未包含任意已配置的键，则不进行覆盖，继续使用 escaper 的默认 `proxy_addr`。
 - 端口：根据入站协议选择（HTTP / SOCKS5），均可配置。
 - 可配置是否拒绝未知键、是否强制层级（例如子键必须有父键）。
 
@@ -336,7 +336,6 @@ server:
       separator: "-"
       # 可选后缀（例如本地测试）：
       # domain_suffix: ".localhost"
-      global_label: "global"
       http_port: 10000
       socks5_port: 10001
       strip_suffix_for_auth: true
@@ -344,13 +343,13 @@ server:
 
 行为说明：
 - 用户名 `user+label1=foo+label2=bar` → 主机 `foo-bar`，HTTP 入站端口 `10000`。
+- 若用户名中未包含任意已配置的键，则不进行覆盖，继续使用 escaper 的 `proxy_addr`。
 - 非法参数（未知键或层级违例）会导致 HTTP 返回 400 Bad Request；SOCKS5 返回标准错误码并拒绝请求。
 
 出口回退说明：
 - 代理串联出口（proxy_http / proxy_socks5 / …）在初始化时必须配置至少一个 `proxy_addr`。
 - 当用户名参数存在且认证成功时，计算得到的 host:port 会覆盖该连接的 `proxy_addr`。
-- 如果希望对“未提供用户名参数”的请求提供真实回退路径（例如允许匿名），请将 `proxy_addr` 设置为默认下一跳
-  （本示例可用：HTTP → 127.0.0.1:10000，SOCKS5 → 127.0.0.1:10001）。否则示例中的占位值不会被使用。
+- 当用户名中没有任何已配置的键时，不进行覆盖，直接使用 `proxy_addr` 作为回退。
 
 ### 连接限速
 

--- a/g3proxy/examples/sticky-username-params-escaper/g3proxy.yaml
+++ b/g3proxy/examples/sticky-username-params-escaper/g3proxy.yaml
@@ -1,0 +1,74 @@
+# Go to sticky_http_socks and username-params-escaper examples to learn more.
+# Those have many more comments.
+# This one is deliberately kept minimal.
+sticky:
+  enabled: true
+  url: redis://localhost:6379/0
+  prefix: g3proxy:sticky
+  default_ttl: 60s
+  max_ttl: 1h
+
+server:
+  - name: http-in
+    type: http_proxy
+    escaper: dyn_http_chain
+    user_group: default
+    listen:
+      address: "127.0.0.1:13128"
+    username_params_to_escaper_addr:
+      keys_for_host: [label1, label2, label3, label4, opt]
+      floating_keys: [opt]
+      require_hierarchy: true
+      reject_unknown_keys: false
+      reject_duplicate_keys: true
+      separator: "-"
+      domain_suffix: ".localhost"
+      http_port: 10000
+      socks5_port: 10001
+      strip_suffix_for_auth: true
+
+  - name: socks-in
+    type: socks_proxy
+    escaper: dyn_socks_chain
+    user_group: default
+    listen:
+      address: "127.0.0.1:11080"
+    enable_udp_associate: true
+    username_params_to_escaper_addr:
+      keys_for_host: [label1, label2, label3, label4, opt]
+      floating_keys: [opt]
+      require_hierarchy: true
+      reject_unknown_keys: false
+      reject_duplicate_keys: true
+      separator: "-"
+      domain_suffix: ".localhost"
+      http_port: 10000
+      socks5_port: 10001
+      strip_suffix_for_auth: true
+
+resolver:
+  - name: sys
+    type: c-ares
+    server: 127.0.0.1:5300
+
+escaper:
+  - name: dyn_http_chain
+    type: proxy_http
+    resolver: sys
+    proxy_addr:
+      - myservice.test:80
+
+  - name: dyn_socks_chain
+    type: proxy_socks5
+    resolver: sys
+    proxy_addr:
+      - myservice.test:1080
+
+user_group:
+  - name: default
+    static_users:
+      - name: user
+        # DEMO ONLY: accept any password (token: null).
+        token: ~
+
+log: stdout

--- a/g3proxy/examples/sticky_http_socks/env/Corefile
+++ b/g3proxy/examples/sticky_http_socks/env/Corefile
@@ -1,0 +1,14 @@
+. {
+  log
+  errors
+  # Shuffle A record order for round-robin style responses
+  loadbalance
+  hosts {
+    10.10.0.2 myservice.test
+    10.10.0.3 myservice.test
+    10.10.0.4 myservice.test
+    fallthrough
+    ttl 5
+  }
+  forward . 1.1.1.1 8.8.8.8
+}

--- a/g3proxy/examples/sticky_http_socks/env/README.md
+++ b/g3proxy/examples/sticky_http_socks/env/README.md
@@ -1,0 +1,88 @@
+# Sticky HTTP/SOCKS Env
+
+This directory provides a small, local environment to simulate three upstream proxies behind a single hostname for the `examples/sticky_http_socks` demo. It sets up:
+
+- `myservice.test` DNS that round-robins to `10.10.0.2`, `10.10.0.3`, `10.10.0.4` via CoreDNS.
+- Loopback IP aliases for those addresses on your host.
+- Port-forwarding containers that expose `10.10.0.{2,3,4}:80` and forward to host ports `8081/8082/8083`.
+
+Use this to point `g3proxy` at multiple upstream proxies as defined in `examples/sticky_http_socks/g3proxy.yaml` and verify sticky routing behavior.
+
+## What’s here
+
+- `Corefile`: CoreDNS config mapping `myservice.test` to three IPs and forwarding other DNS to public resolvers.
+- `docker-compose.yaml`: Runs CoreDNS and three minimal forwarders for port 80 → host `8081/8082/8083` and port 1080 → host `1081/1082/1083`.
+- `setup.sh`: Adds loopback IP aliases, configures macOS resolver for `*.test` to use CoreDNS on `127.0.0.1:5300`, and starts the stack.
+- `teardown.sh`: Stops containers and reverts resolver and loopback alias changes.
+- `usage.sh`: Quick-start snippet showing common commands.
+
+## Prerequisites
+
+- macOS (the scripts use `lo0` aliases and `/etc/resolver`).
+- Docker + Docker Compose v2 (`docker compose`).
+- `sudo` privileges (to add loopback aliases and write `/etc/resolver/test`).
+- Three local upstream proxies listening on host ports `8081`, `8082`, `8083` (HTTP), and optionally SOCKS5 proxies on `1081`, `1082`, `1083` if you want to test the SOCKS path.
+
+## Quick start
+
+1) Make scripts executable and run setup (prompts for sudo):
+
+```bash
+cd examples/sticky_http_socks/env
+chmod +x setup.sh teardown.sh
+./setup.sh
+```
+
+2) Verify DNS and connectivity:
+
+```bash
+# DNS should show multiple A records
+/usr/bin/dscacheutil -q host -a name myservice.test
+
+# TCP connectivity to the virtual VIP
+nc -vz myservice.test 80
+nc -vz myservice.test 1080
+```
+
+3) Exercise via HTTP proxy (round-robin across 3 backends):
+
+```bash
+/usr/bin/curl -v -x http://myservice.test:80 http://ipinfo.io
+/usr/bin/curl -v -x http://myservice.test:80 http://ipinfo.io
+/usr/bin/curl -v -x http://myservice.test:80 http://ipinfo.io
+```
+
+You should observe requests distributed across the three upstreams connected at `8081/8082/8083`.
+
+## Using with g3proxy
+
+- Sample config: `examples/sticky_http_socks/g3proxy.yaml` already references:
+  - HTTP upstreams: `10.10.0.2:80`, `10.10.0.3:80`, `10.10.0.4:80` (backed by the port-forwarders → `8081/8082/8083`).
+  - SOCKS5 upstreams: `10.10.0.2:1080`, `10.10.0.3:1080`, `10.10.0.4:1080`.
+- For HTTP, no extra changes are needed if your three HTTP proxies are on `8081/2/3`.
+- For SOCKS5, this env already forwards `10.10.0.{2,3,4}:1080` → host `1081/1082/1083`; run your local SOCKS5 servers on those host ports to match the example config.
+
+Start `g3proxy` with the example config and test via its HTTP/SOCKS listeners as desired.
+
+## Cleanup
+
+When finished:
+
+```bash
+./teardown.sh
+```
+
+This stops containers, removes loopback aliases, and restores resolver settings.
+
+## Notes
+
+- The resolver setup targets the `test` TLD only (`/etc/resolver/test`), keeping normal DNS unaffected.
+- CoreDNS listens on `127.0.0.1:5300`; other domains are forwarded to public resolvers (`1.1.1.1`, `8.8.8.8`).
+- If ports `8081/8082/8083` are busy, adjust the compose file and your upstreams to matching ports.
+- If ports `1081/1082/1083` are busy, update both the compose forwarders and your local SOCKS5 servers accordingly.
+
+### Troubleshooting
+
+- Error `socat: not found` in container logs: the image installs `socat` at startup via `apk`. If the install fails (e.g., no internet), the container exits. Ensure Docker has outbound internet or prebuild an image with `socat` included. As a quick check:
+  - Run `docker compose pull` and retry `docker compose up -d`.
+  - Verify your network/proxy settings allow Alpine packages to download.

--- a/g3proxy/examples/sticky_http_socks/env/README.md
+++ b/g3proxy/examples/sticky_http_socks/env/README.md
@@ -1,6 +1,6 @@
 # Sticky HTTP/SOCKS Env
 
-This directory provides a small, local environment to simulate three upstream proxies behind a single hostname for the `examples/sticky_http_socks` demo. It sets up:
+This directory provides a small, local environment to set up three upstream proxies behind a single hostname for the `examples/sticky_http_socks` demo. It sets up:
 
 - `myservice.test` DNS that round-robins to `10.10.0.2`, `10.10.0.3`, `10.10.0.4` via CoreDNS.
 - Loopback IP aliases for those addresses on your host.

--- a/g3proxy/examples/sticky_http_socks/env/docker-compose.yaml
+++ b/g3proxy/examples/sticky_http_socks/env/docker-compose.yaml
@@ -1,0 +1,38 @@
+services:
+  coredns:
+    image: coredns/coredns:latest
+    command: ["-conf", "/Corefile"]
+    volumes:
+      - ./Corefile:/Corefile:ro
+    ports:
+      - "5300:53/udp"
+      - "5300:53/tcp"
+    restart: unless-stopped
+
+  headless_1:
+    image: alpine:latest
+    # Publish VIP 10.10.0.2:80 -> host:8081 (HTTP) and 10.10.0.2:1080 -> host:1081 (SOCKS5)
+    # Ensure socat is installed before starting; exit early if install fails.
+    command: [ "sh", "-c", "set -e; apk add --no-cache socat; socat -d -d TCP-LISTEN:80,fork,reuseaddr TCP:host.docker.internal:8081 & exec socat -d -d TCP-LISTEN:1080,fork,reuseaddr TCP:host.docker.internal:1081" ]
+    ports:
+      - "10.10.0.2:80:80"
+      - "10.10.0.2:1080:1080"
+    restart: unless-stopped
+
+  headless_2:
+    image: alpine:latest
+    # 10.10.0.3:80 -> host:8082 and 10.10.0.3:1080 -> host:1082
+    command: [ "sh", "-c", "set -e; apk add --no-cache socat; socat -d -d TCP-LISTEN:80,fork,reuseaddr TCP:host.docker.internal:8082 & exec socat -d -d TCP-LISTEN:1080,fork,reuseaddr TCP:host.docker.internal:1082" ]
+    ports:
+      - "10.10.0.3:80:80"
+      - "10.10.0.3:1080:1080"
+    restart: unless-stopped
+
+  headless_3:
+    image: alpine:latest
+    # 10.10.0.4:80 -> host:8083 and 10.10.0.4:1080 -> host:1083
+    command: [ "sh", "-c", "set -e; apk add --no-cache socat; socat -d -d TCP-LISTEN:80,fork,reuseaddr TCP:host.docker.internal:8083 & exec socat -d -d TCP-LISTEN:1080,fork,reuseaddr TCP:host.docker.internal:1083" ]
+    ports:
+      - "10.10.0.4:80:80"
+      - "10.10.0.4:1080:1080"
+    restart: unless-stopped

--- a/g3proxy/examples/sticky_http_socks/env/setup.sh
+++ b/g3proxy/examples/sticky_http_socks/env/setup.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# 1) Add host loopback aliases (one-time per boot; idempotent)
+for ip in 10.10.0.2 10.10.0.3 10.10.0.4; do
+  if ! ifconfig lo0 | grep -q "inet ${ip} "; then
+    sudo ifconfig lo0 alias ${ip}/32
+  fi
+done
+
+# 2) Route *.test to CoreDNS on localhost:5300
+sudo mkdir -p /etc/resolver
+printf "nameserver 127.0.0.1\nport 5300\n" | sudo tee /etc/resolver/test >/dev/null
+sudo dscacheutil -flushcache || true
+sudo killall -HUP mDNSResponder 2>/dev/null || true
+
+# 3) Bring up containers
+docker compose up -d
+
+echo "Ready.
+
+Test DNS:
+  dscacheutil -q host -a name myservice.test
+
+Test TCP:
+  nc -vz myservice.test 80
+  nc -vz myservice.test 1080
+
+Test HTTP proxy (use system curl):
+  /usr/bin/curl -v -x http://myservice.test:80 http://ipinfo.io
+
+Test SOCKS5 proxy (use system curl):
+  /usr/bin/curl -v --socks5-hostname myservice.test:1080 http://ipinfo.io
+
+(Ensure your 3 local proxies are listening on 8081/8082/8083.)"

--- a/g3proxy/examples/sticky_http_socks/env/teardown.sh
+++ b/g3proxy/examples/sticky_http_socks/env/teardown.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+docker compose down -v
+
+# remove host aliases
+for ip in 10.10.0.2 10.10.0.3 10.10.0.4; do
+  sudo ifconfig lo0 -alias ${ip} || true
+done
+
+sudo rm -f /etc/resolver/test
+sudo dscacheutil -flushcache || true
+sudo killall -HUP mDNSResponder 2>/dev/null || true
+
+echo "Cleaned up."

--- a/g3proxy/examples/sticky_http_socks/env/usage.sh
+++ b/g3proxy/examples/sticky_http_socks/env/usage.sh
@@ -1,0 +1,15 @@
+chmod +x setup.sh teardown.sh
+./setup.sh
+
+# verify round-robin via proxy
+/usr/bin/curl -v -x http://myservice.test:80 http://ipinfo.io
+/usr/bin/curl -v -x http://myservice.test:80 http://ipinfo.io
+/usr/bin/curl -v -x http://myservice.test:80 http://ipinfo.io
+
+# verify SOCKS5 path if you have local SOCKS servers on 1081/1082/1083
+/usr/bin/curl -v --socks5-hostname myservice.test:1080 http://ipinfo.io
+/usr/bin/curl -v --socks5-hostname myservice.test:1080 http://ipinfo.io
+/usr/bin/curl -v --socks5-hostname myservice.test:1080 http://ipinfo.io
+
+# when done
+./teardown.sh

--- a/g3proxy/examples/sticky_http_socks/g3proxy.yaml
+++ b/g3proxy/examples/sticky_http_socks/g3proxy.yaml
@@ -1,4 +1,5 @@
 sticky:
+  enabled: true
   url: redis://localhost:6379/0
   prefix: g3proxy:sticky
   # default sticky TTL and maximum permitted TTL

--- a/g3proxy/examples/sticky_http_socks/g3proxy.yaml
+++ b/g3proxy/examples/sticky_http_socks/g3proxy.yaml
@@ -1,0 +1,56 @@
+sticky:
+  url: redis://localhost:6379/0
+  prefix: g3proxy:sticky
+  # default sticky TTL and maximum permitted TTL
+  default_ttl: 60s
+  max_ttl: 1h
+
+server:
+  - name: http
+    type: http_proxy
+    escaper: http
+    user_group: users
+    listen:
+      address: "[::]:13128"
+    flush_task_log_on_created: true
+  - name: socks
+    type: socks_proxy
+    escaper: socks5
+    enable_udp_associate: true
+    user_group: users
+    listen:
+      address: "[::]:11080"
+    flush_task_log_on_created: true
+
+escaper:
+  - name: http
+    type: proxy_http
+    proxy_addr: myservice.test:80
+    no_ipv6: true
+    resolver: default
+    resolve_strategy: IPv4Only
+    tcp_sock_speed_limit: 80M
+  - name: socks5
+    type: proxy_socks5
+    proxy_addr: myservice.test:1080
+    no_ipv6: true
+    resolver: default
+    resolve_strategy: IPv4Only
+    tcp_sock_speed_limit: 80M
+
+resolver:
+  - name: default
+    type: c-ares
+    # for dev purposes we're running coredns via docker on
+    # port 5300 to test/demo handling multiple A records.
+    # just can just remove the line below (server: ...)
+    # and resolver will use /etc/resolv.conf
+    server: 127.0.0.1:5300
+
+user_group:
+  - name: users
+    static_users:
+      - name: user
+        token: ~
+
+log: stdout

--- a/g3proxy/examples/username-params-escaper/g3proxy.yaml
+++ b/g3proxy/examples/username-params-escaper/g3proxy.yaml
@@ -1,0 +1,113 @@
+---
+# Minimal end-to-end example: derive next-hop escaper address from proxy username params.
+#
+# Highlights
+# - HTTP server on 13128 and SOCKS5 server on 11080
+# - Username format: base+key1=val1+key2=val2
+# - Keys are ordered and optional; hierarchy can be enforced (child requires parent)
+# - Computed service host = join(values, '-') or 'global' when no params
+# - Port chosen by inbound protocol: 10000 (HTTP), 10001 (SOCKS5)
+# - Base username is used for auth (suffix stripped)
+
+user_group:
+  - name: default
+    static_users:
+      - name: user
+        # DEMO ONLY: accept any password (token: null). For real use, set a token:
+        #   token:
+        #     salt: <hex>
+        #     md5:  <hex>
+        #     sha1: <hex>
+        # Or:
+        #   token: "$6$mysalt$..."
+        token: ~
+
+server:
+  - name: http-in
+    type: http_proxy
+    escaper: dyn_http_chain
+    user_group: default
+    listen:
+      # Bind IPv4 explicitly to avoid OS-dependent v6-only sockets
+      address: "127.0.0.1:13128"
+    # Map username params to next-hop escaper host:port
+    username_params_to_escaper_addr:
+      # Optional independent (floating) key 'opt' can appear alone or append hierarchically
+      keys_for_host: [label1, label2, label3, label4, opt]
+      floating_keys: [opt]
+      require_hierarchy: true
+      reject_unknown_keys: true
+      reject_duplicate_keys: true
+      separator: "-"
+      # for local testing use ".localhost"
+      # k8s note: c-ares doesn't expand ndots
+      # so use FQDN (e.g. domain_suffix: ".default.svc.cluster.local")
+      domain_suffix: ".localhost"
+      global_label: "global"
+      http_port: 10000
+      socks5_port: 10001
+      strip_suffix_for_auth: true
+
+  - name: socks-in
+    type: socks_proxy
+    escaper: dyn_socks_chain
+    user_group: default
+    listen:
+      # Bind IPv4 explicitly to avoid OS-dependent v6-only sockets
+      address: "127.0.0.1:11080"
+    enable_udp_associate: true
+    username_params_to_escaper_addr:
+      # Optional independent (floating) key 'opt' can appear alone or append hierarchically
+      keys_for_host: [label1, label2, label3, label4, opt]
+      floating_keys: [opt]
+      require_hierarchy: true
+      reject_unknown_keys: true
+      reject_duplicate_keys: true
+      separator: "-"
+      # for local testing use ".localhost"
+      # k8s note: c-ares doesn't expand ndots
+      # so use FQDN (e.g. domain_suffix: ".default.svc.cluster.local")
+      domain_suffix: ".localhost"
+      global_label: "global"
+      http_port: 10000
+      socks5_port: 10001
+      strip_suffix_for_auth: true
+
+resolver:
+  - name: sys
+    type: c-ares
+
+escaper:
+  # NOTE ABOUT proxy_addr BELOW
+  # - proxy_addr is required by proxy_* escapers so they can initialize.
+  # - In this example, the next-hop is computed from the username params per connection,
+  #   so these proxy_addr values are placeholders and are NOT used when params are present.
+  # - If you want a meaningful fallback (e.g., when no username params are supplied
+  #   and you allow anonymous), set proxy_addr to your actual default next-hop, e.g.:
+  #     HTTP  -> 127.0.0.1:10000
+  #     SOCKS -> 127.0.0.1:10001
+
+  # HTTP chaining escaper; overridden per-connection by computed host:port
+  - name: dyn_http_chain
+    type: proxy_http
+    resolver: sys
+    proxy_addr:
+      - "127.0.0.1:3128"   # fallback only; overridden when username params present
+
+  # SOCKS5 chaining escaper; overridden per-connection by computed host:port
+  - name: dyn_socks_chain
+    type: proxy_socks5
+    resolver: sys
+    proxy_addr:
+      - "127.0.0.1:1080"   # fallback only; overridden when username params present
+
+# Testing tips
+# - HTTP:  curl -x http://user+label1=foo+label2=bar:password123@127.0.0.1:8080 http://example.com/
+#   => chosen svc: foo-bar:10000 (mapped to 127.0.0.1:10000)
+# - SOCKS5: curl --socks5 user+label1=foo+label2=bar:password123@127.0.0.1:11080 http://example.com/
+#   => chosen svc: foo-bar:10001 (mapped to 127.0.0.1:10001)
+# - Floating only (independent): curl -x http://user+opt=o123:password@127.0.0.1:8080 http://example.com/
+#   => chosen svc: o123:10000
+# - Combined (hierarchical + floating): curl -x http://user+label1=foo+opt=o123:password@127.0.0.1:8080 http://example.com/
+#   => chosen svc: foo-o123:10000
+log: stdout

--- a/g3proxy/examples/username-params-escaper/g3proxy.yaml
+++ b/g3proxy/examples/username-params-escaper/g3proxy.yaml
@@ -43,7 +43,6 @@ server:
       # k8s note: c-ares doesn't expand ndots
       # so use FQDN (e.g. domain_suffix: ".default.svc.cluster.local")
       domain_suffix: ".localhost"
-      global_label: "global"
       http_port: 10000
       socks5_port: 10001
       strip_suffix_for_auth: true
@@ -68,7 +67,6 @@ server:
       # k8s note: c-ares doesn't expand ndots
       # so use FQDN (e.g. domain_suffix: ".default.svc.cluster.local")
       domain_suffix: ".localhost"
-      global_label: "global"
       http_port: 10000
       socks5_port: 10001
       strip_suffix_for_auth: true
@@ -78,15 +76,6 @@ resolver:
     type: c-ares
 
 escaper:
-  # NOTE ABOUT proxy_addr BELOW
-  # - proxy_addr is required by proxy_* escapers so they can initialize.
-  # - In this example, the next-hop is computed from the username params per connection,
-  #   so these proxy_addr values are placeholders and are NOT used when params are present.
-  # - If you want a meaningful fallback (e.g., when no username params are supplied
-  #   and you allow anonymous), set proxy_addr to your actual default next-hop, e.g.:
-  #     HTTP  -> 127.0.0.1:10000
-  #     SOCKS -> 127.0.0.1:10001
-
   # HTTP chaining escaper; overridden per-connection by computed host:port
   - name: dyn_http_chain
     type: proxy_http

--- a/g3proxy/src/auth/source/mod.rs
+++ b/g3proxy/src/auth/source/mod.rs
@@ -18,7 +18,7 @@ use crate::config::auth::{UserConfig, UserDynamicSource};
 #[cfg(feature = "lua")]
 mod lua;
 
-#[cfg(feature = "python")]
+#[cfg(all(feature = "python", not(test)))]
 mod python;
 
 pub(super) async fn load_initial_users(
@@ -33,7 +33,7 @@ pub(super) async fn load_initial_users(
                 .fetch_cached_records(&group_config.dynamic_cache)
                 .await?
         }
-        #[cfg(feature = "python")]
+        #[cfg(all(feature = "python", not(test)))]
         UserDynamicSource::Python(config) => {
             config
                 .fetch_cached_records(&group_config.dynamic_cache)
@@ -81,7 +81,7 @@ pub(super) fn new_fetch_job(
                 UserDynamicSource::Lua(config) => {
                     lua::fetch_records(config, &group_config.dynamic_cache).await
                 }
-                #[cfg(feature = "python")]
+                #[cfg(all(feature = "python", not(test)))]
                 UserDynamicSource::Python(config) => {
                     python::fetch_records(config, &group_config.dynamic_cache).await
                 }

--- a/g3proxy/src/auth/source/python.rs
+++ b/g3proxy/src/auth/source/python.rs
@@ -124,6 +124,8 @@ async fn call_python_fetch(script: PathBuf) -> anyhow::Result<String> {
     let code = unsafe { CString::from_vec_unchecked(code.into_bytes()) };
 
     tokio::task::spawn_blocking(move || {
+        // Ensure the Python interpreter is initialized for use from any thread.
+        Python::initialize();
         Python::attach(|py| {
             let code = PyModule::from_code(py, &code, c"", c"").map_err(|e| {
                 anyhow!(
@@ -180,6 +182,7 @@ async fn call_python_report_ok(script: PathBuf) -> anyhow::Result<()> {
     let code = unsafe { CString::from_vec_unchecked(code.into_bytes()) };
 
     tokio::task::spawn_blocking(move || {
+        Python::initialize();
         Python::attach(|py| {
             let code = PyModule::from_code(py, &code, c"", c"").map_err(|e| {
                 anyhow!(
@@ -222,6 +225,7 @@ async fn call_python_report_err(script: PathBuf, e: String) -> anyhow::Result<()
     let code = unsafe { CString::from_vec_unchecked(code.into_bytes()) };
 
     tokio::task::spawn_blocking(move || {
+        Python::initialize();
         Python::attach(|py| {
             let code = PyModule::from_code(py, &code, c"", c"").map_err(|e| {
                 anyhow!(

--- a/g3proxy/src/config/auth/source/mod.rs
+++ b/g3proxy/src/config/auth/source/mod.rs
@@ -18,9 +18,9 @@ pub(crate) mod lua;
 #[cfg(feature = "lua")]
 pub(crate) use lua::UserDynamicLuaSource;
 
-#[cfg(feature = "python")]
+#[cfg(all(feature = "python", not(test)))]
 pub(crate) mod python;
-#[cfg(feature = "python")]
+#[cfg(all(feature = "python", not(test)))]
 pub(crate) use python::UserDynamicPythonSource;
 
 const CONFIG_KEY_SOURCE_TYPE: &str = "type";
@@ -30,7 +30,7 @@ pub(crate) enum UserDynamicSource {
     File(Arc<UserDynamicFileSource>),
     #[cfg(feature = "lua")]
     Lua(Arc<UserDynamicLuaSource>),
-    #[cfg(feature = "python")]
+    #[cfg(all(feature = "python", not(test)))]
     Python(Arc<UserDynamicPythonSource>),
 }
 
@@ -50,7 +50,7 @@ impl UserDynamicSource {
                         let source = UserDynamicLuaSource::parse_map(map, lookup_dir)?;
                         Ok(UserDynamicSource::Lua(Arc::new(source)))
                     }
-                    #[cfg(feature = "python")]
+                    #[cfg(all(feature = "python", not(test)))]
                     "python" => {
                         let source = UserDynamicPythonSource::parse_map(map, lookup_dir)?;
                         Ok(UserDynamicSource::Python(Arc::new(source)))

--- a/g3proxy/src/config/mod.rs
+++ b/g3proxy/src/config/mod.rs
@@ -23,6 +23,7 @@ pub(crate) mod escaper;
 pub(crate) mod log;
 pub(crate) mod resolver;
 pub(crate) mod server;
+pub(crate) mod sticky;
 
 pub fn load() -> anyhow::Result<&'static Path> {
     let config_file =
@@ -68,6 +69,7 @@ fn reload_doc(map: &yaml::Hash) -> anyhow::Result<()> {
         g3_daemon::opts::config_dir().ok_or_else(|| anyhow!("no valid config dir has been set"))?;
     g3_yaml::foreach_kv(map, |k, v| match g3_yaml::key::normalize(k).as_str() {
         "runtime" | "worker" | "log" | "stat" | "controller" => Ok(()),
+        "sticky" => sticky::load(v, conf_dir),
         "escaper" => escaper::load_all(v, conf_dir),
         "server" => server::load_all(v, conf_dir),
         "resolver" => resolver::load_all(v, conf_dir),
@@ -87,6 +89,7 @@ fn load_doc(map: &yaml::Hash) -> anyhow::Result<()> {
         "log" => log::load(v, conf_dir),
         "stat" => g3_daemon::stat::config::load(v, crate::build::PKG_NAME),
         "controller" => g3_daemon::control::config::load(v),
+        "sticky" => sticky::load(v, conf_dir),
         "escaper" => escaper::load_all(v, conf_dir),
         "server" => server::load_all(v, conf_dir),
         "resolver" => resolver::load_all(v, conf_dir),

--- a/g3proxy/src/config/server/http_proxy.rs
+++ b/g3proxy/src/config/server/http_proxy.rs
@@ -31,6 +31,7 @@ use super::{
     AnyServerConfig, IDLE_CHECK_DEFAULT_DURATION, IDLE_CHECK_DEFAULT_MAX_COUNT,
     IDLE_CHECK_MAXIMUM_DURATION, ServerConfig, ServerConfigDiffAction,
 };
+use super::username_params_to_escaper::UsernameParamsToEscaperConfig;
 
 const SERVER_CONFIG_TYPE: &str = "HttpProxy";
 
@@ -98,7 +99,7 @@ pub(crate) struct HttpProxyServerConfig {
     pub(crate) steal_forwarded_for: bool,
     pub(crate) extra_metrics_tags: Option<Arc<MetricTagMap>>,
     // Optional: derive next-hop escaper addr from username params
-    pub(crate) username_params_to_escaper_addr: Option<super::username_params_to_escaper::UsernameParamsToEscaperConfig>,
+    pub(crate) username_params_to_escaper_addr: Option<UsernameParamsToEscaperConfig>,
 }
 
 impl HttpProxyServerConfig {
@@ -196,7 +197,7 @@ impl HttpProxyServerConfig {
             "username_params_to_escaper_addr" => {
                 match v {
                     Yaml::Hash(map) => {
-                        let c = super::username_params_to_escaper::UsernameParamsToEscaperConfig::parse(map, self.position.clone())
+                        let c = UsernameParamsToEscaperConfig::parse(map, self.position.clone())
                             .context(format!("invalid username_params_to_escaper_addr value for key {k}"))?;
                         self.username_params_to_escaper_addr = Some(c);
                         Ok(())

--- a/g3proxy/src/config/server/http_proxy.rs
+++ b/g3proxy/src/config/server/http_proxy.rs
@@ -458,36 +458,6 @@ impl HttpProxyServerConfig {
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use yaml_rust::YamlLoader;
-
-    #[test]
-    fn parse_with_username_params_section() {
-        let s = r#"---
-type: http_proxy
-name: s1
-escaper: e1
-username_params_to_escaper_addr:
-  keys_for_host: [k1, k2]
-  require_hierarchy: true
-  floating_keys: [k2]
-  http_port: 12345
-  socks5_port: 23456
-"#;
-        let docs = YamlLoader::load_from_str(s).unwrap();
-        let map = docs[0].as_hash().unwrap();
-        let cfg = HttpProxyServerConfig::parse(map, None).unwrap();
-        let u = cfg.username_params_to_escaper_addr.as_ref().unwrap();
-        assert_eq!(u.keys_for_host, vec!["k1", "k2"]);
-        assert_eq!(u.floating_keys, vec!["k2"]);
-        assert!(u.require_hierarchy);
-        assert_eq!(u.http_port, 12345);
-        assert_eq!(u.socks5_port, 23456);
-    }
-}
-
 impl ServerConfig for HttpProxyServerConfig {
     fn name(&self) -> &NodeName {
         &self.name
@@ -545,5 +515,35 @@ impl ServerConfig for HttpProxyServerConfig {
     #[inline]
     fn task_max_idle_count(&self) -> usize {
         self.task_idle_max_count
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use yaml_rust::YamlLoader;
+
+    #[test]
+    fn parse_with_username_params_section() {
+        let s = r#"---
+type: http_proxy
+name: s1
+escaper: e1
+username_params_to_escaper_addr:
+  keys_for_host: [k1, k2]
+  require_hierarchy: true
+  floating_keys: [k2]
+  http_port: 12345
+  socks5_port: 23456
+"#;
+        let docs = YamlLoader::load_from_str(s).unwrap();
+        let map = docs[0].as_hash().unwrap();
+        let cfg = HttpProxyServerConfig::parse(map, None).unwrap();
+        let u = cfg.username_params_to_escaper_addr.as_ref().unwrap();
+        assert_eq!(u.keys_for_host, vec!["k1", "k2"]);
+        assert_eq!(u.floating_keys, vec!["k2"]);
+        assert!(u.require_hierarchy);
+        assert_eq!(u.http_port, 12345);
+        assert_eq!(u.socks5_port, 23456);
     }
 }

--- a/g3proxy/src/config/server/http_proxy.rs
+++ b/g3proxy/src/config/server/http_proxy.rs
@@ -457,6 +457,36 @@ impl HttpProxyServerConfig {
     }
 }
 
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use yaml_rust::YamlLoader;
+
+    #[test]
+    fn parse_with_username_params_section() {
+        let s = r#"---
+type: http_proxy
+name: s1
+escaper: e1
+username_params_to_escaper_addr:
+  keys_for_host: [k1, k2]
+  require_hierarchy: true
+  floating_keys: [k2]
+  http_port: 12345
+  socks5_port: 23456
+"#;
+        let docs = YamlLoader::load_from_str(s).unwrap();
+        let map = docs[0].as_hash().unwrap();
+        let cfg = HttpProxyServerConfig::parse(map, None).unwrap();
+        let u = cfg.username_params_to_escaper_addr.as_ref().unwrap();
+        assert_eq!(u.keys_for_host, vec!["k1", "k2"]);
+        assert_eq!(u.floating_keys, vec!["k2"]);
+        assert!(u.require_hierarchy);
+        assert_eq!(u.http_port, 12345);
+        assert_eq!(u.socks5_port, 23456);
+    }
+}
+
 impl ServerConfig for HttpProxyServerConfig {
     fn name(&self) -> &NodeName {
         &self.name

--- a/g3proxy/src/config/server/mod.rs
+++ b/g3proxy/src/config/server/mod.rs
@@ -34,6 +34,7 @@ pub(crate) mod http_rproxy;
 pub(crate) mod sni_proxy;
 pub(crate) mod socks_proxy;
 pub(crate) mod tcp_stream;
+pub(crate) mod username_params_to_escaper;
 #[cfg(any(
     target_os = "linux",
     target_os = "freebsd",

--- a/g3proxy/src/config/server/mod.rs
+++ b/g3proxy/src/config/server/mod.rs
@@ -121,6 +121,7 @@ pub(crate) trait ServerConfig {
 }
 
 #[derive(Clone, Debug, AnyConfig)]
+#[allow(clippy::large_enum_variant)]
 #[def_fn(name, &NodeName)]
 #[def_fn(position, Option<YamlDocPosition>)]
 #[def_fn(r#type, &'static str)]

--- a/g3proxy/src/config/server/socks_proxy.rs
+++ b/g3proxy/src/config/server/socks_proxy.rs
@@ -383,34 +383,6 @@ impl SocksProxyServerConfig {
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use yaml_rust::YamlLoader;
-
-    #[test]
-    fn parse_with_username_params_section() {
-        let s = r#"---
-type: socks_proxy
-name: s1
-escaper: e1
-username_params_to_escaper_addr:
-  keys_for_host: [k1, k2]
-  require_hierarchy: false
-  floating_keys: [k2]
-  separator: "+"
-"#;
-        let docs = YamlLoader::load_from_str(s).unwrap();
-        let map = docs[0].as_hash().unwrap();
-        let cfg = SocksProxyServerConfig::parse(map, None).unwrap();
-        let u = cfg.username_params_to_escaper_addr.as_ref().unwrap();
-        assert_eq!(u.keys_for_host, vec!["k1", "k2"]);
-        assert_eq!(u.floating_keys, vec!["k2"]);
-        assert!(!u.require_hierarchy);
-        assert_eq!(u.separator, "+");
-    }
-}
-
 impl ServerConfig for SocksProxyServerConfig {
     fn name(&self) -> &NodeName {
         &self.name
@@ -468,5 +440,33 @@ impl ServerConfig for SocksProxyServerConfig {
     #[inline]
     fn task_max_idle_count(&self) -> usize {
         self.task_idle_max_count
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use yaml_rust::YamlLoader;
+
+    #[test]
+    fn parse_with_username_params_section() {
+        let s = r#"---
+type: socks_proxy
+name: s1
+escaper: e1
+username_params_to_escaper_addr:
+  keys_for_host: [k1, k2]
+  require_hierarchy: false
+  floating_keys: [k2]
+  separator: "+"
+"#;
+        let docs = YamlLoader::load_from_str(s).unwrap();
+        let map = docs[0].as_hash().unwrap();
+        let cfg = SocksProxyServerConfig::parse(map, None).unwrap();
+        let u = cfg.username_params_to_escaper_addr.as_ref().unwrap();
+        assert_eq!(u.keys_for_host, vec!["k1", "k2"]);
+        assert_eq!(u.floating_keys, vec!["k2"]);
+        assert!(!u.require_hierarchy);
+        assert_eq!(u.separator, "+");
     }
 }

--- a/g3proxy/src/config/server/socks_proxy.rs
+++ b/g3proxy/src/config/server/socks_proxy.rs
@@ -27,6 +27,7 @@ use super::{
     AnyServerConfig, IDLE_CHECK_DEFAULT_DURATION, IDLE_CHECK_DEFAULT_MAX_COUNT,
     IDLE_CHECK_MAXIMUM_DURATION, ServerConfig, ServerConfigDiffAction,
 };
+use super::username_params_to_escaper::UsernameParamsToEscaperConfig;
 
 const SERVER_CONFIG_TYPE: &str = "SocksProxy";
 
@@ -82,7 +83,7 @@ pub(crate) struct SocksProxyServerConfig {
     pub(crate) transmute_udp_echo_ip: Option<FxHashMap<IpAddr, IpAddr>>,
     pub(crate) extra_metrics_tags: Option<Arc<MetricTagMap>>,
     // Optional: derive next-hop escaper addr from username params
-    pub(crate) username_params_to_escaper_addr: Option<super::username_params_to_escaper::UsernameParamsToEscaperConfig>,
+    pub(crate) username_params_to_escaper_addr: Option<UsernameParamsToEscaperConfig>,
 }
 
 impl SocksProxyServerConfig {
@@ -167,7 +168,7 @@ impl SocksProxyServerConfig {
             "username_params_to_escaper_addr" => {
                 match v {
                     Yaml::Hash(map) => {
-                        let c = super::username_params_to_escaper::UsernameParamsToEscaperConfig::parse(map, self.position.clone())
+                        let c = UsernameParamsToEscaperConfig::parse(map, self.position.clone())
                             .context(format!("invalid username_params_to_escaper_addr value for key {k}"))?;
                         self.username_params_to_escaper_addr = Some(c);
                         Ok(())

--- a/g3proxy/src/config/server/socks_proxy.rs
+++ b/g3proxy/src/config/server/socks_proxy.rs
@@ -382,6 +382,34 @@ impl SocksProxyServerConfig {
     }
 }
 
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use yaml_rust::YamlLoader;
+
+    #[test]
+    fn parse_with_username_params_section() {
+        let s = r#"---
+type: socks_proxy
+name: s1
+escaper: e1
+username_params_to_escaper_addr:
+  keys_for_host: [k1, k2]
+  require_hierarchy: false
+  floating_keys: [k2]
+  separator: "+"
+"#;
+        let docs = YamlLoader::load_from_str(s).unwrap();
+        let map = docs[0].as_hash().unwrap();
+        let cfg = SocksProxyServerConfig::parse(map, None).unwrap();
+        let u = cfg.username_params_to_escaper_addr.as_ref().unwrap();
+        assert_eq!(u.keys_for_host, vec!["k1", "k2"]);
+        assert_eq!(u.floating_keys, vec!["k2"]);
+        assert!(!u.require_hierarchy);
+        assert_eq!(u.separator, "+");
+    }
+}
+
 impl ServerConfig for SocksProxyServerConfig {
     fn name(&self) -> &NodeName {
         &self.name

--- a/g3proxy/src/config/server/username_params_to_escaper.rs
+++ b/g3proxy/src/config/server/username_params_to_escaper.rs
@@ -1,0 +1,153 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright 2025 ByteDance and/or its affiliates.
+ */
+
+use std::borrow::Cow;
+
+use anyhow::{Context, anyhow};
+use yaml_rust::{Yaml, yaml};
+
+use g3_yaml::YamlDocPosition;
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct UsernameParamsToEscaperConfig {
+    position: Option<YamlDocPosition>,
+    /// ordered keys that will be used to form the host label
+    pub(crate) keys_for_host: Vec<String>,
+    /// require that if a later key appears, all its ancestors (earlier keys) must also appear
+    pub(crate) require_hierarchy: bool,
+    /// keys that can appear independently without requiring earlier keys (e.g., a generic optional key)
+    pub(crate) floating_keys: Vec<String>,
+    /// reject unknown keys not present in `keys_for_host`
+    pub(crate) reject_unknown_keys: bool,
+    /// reject duplicate keys
+    pub(crate) reject_duplicate_keys: bool,
+    /// separator used between labels
+    pub(crate) separator: String,
+    /// optional domain suffix appended to computed host (e.g., ".svc.local")
+    pub(crate) domain_suffix: Option<String>,
+    /// label used when 0 kv pairs (global)
+    pub(crate) global_label: String,
+    /// default port for HTTP proxy upstream selection
+    pub(crate) http_port: u16,
+    /// default port for SOCKS5 proxy upstream selection
+    pub(crate) socks5_port: u16,
+    /// if true, only the base part before '+' is used for auth username
+    pub(crate) strip_suffix_for_auth: bool,
+}
+
+impl UsernameParamsToEscaperConfig {
+    pub(crate) fn new(position: Option<YamlDocPosition>) -> Self {
+        UsernameParamsToEscaperConfig {
+            position,
+            keys_for_host: Vec::new(),
+            require_hierarchy: true,
+            floating_keys: Vec::new(),
+            reject_unknown_keys: true,
+            reject_duplicate_keys: true,
+            separator: "-".to_string(),
+            domain_suffix: None,
+            global_label: "global".to_string(),
+            http_port: 10000,
+            socks5_port: 10001,
+            strip_suffix_for_auth: true,
+        }
+    }
+
+    pub(crate) fn parse(map: &yaml::Hash, position: Option<YamlDocPosition>) -> anyhow::Result<Self> {
+        let mut c = Self::new(position);
+        g3_yaml::foreach_kv(map, |k, v| c.set(k, v))?;
+        c.check()?;
+        Ok(c)
+    }
+
+    fn set(&mut self, k: &str, v: &Yaml) -> anyhow::Result<()> {
+        match g3_yaml::key::normalize(k).as_str() {
+            "keys_for_host" | "keys" => {
+                self.keys_for_host = g3_yaml::value::as_list(v, |v| g3_yaml::value::as_string(v))
+                    .context(format!("invalid string list value for key {k}"))?;
+                Ok(())
+            }
+            "require_hierarchy" => {
+                self.require_hierarchy = g3_yaml::value::as_bool(v)?;
+                Ok(())
+            }
+            "reject_unknown_keys" => {
+                self.reject_unknown_keys = g3_yaml::value::as_bool(v)?;
+                Ok(())
+            }
+            "floating_keys" | "floating" => {
+                self.floating_keys = g3_yaml::value::as_list(v, |v| g3_yaml::value::as_string(v))
+                    .context(format!("invalid string list value for key {k}"))?;
+                Ok(())
+            }
+            "reject_duplicate_keys" => {
+                self.reject_duplicate_keys = g3_yaml::value::as_bool(v)?;
+                Ok(())
+            }
+            "separator" => {
+                self.separator = g3_yaml::value::as_string(v)?;
+                Ok(())
+            }
+            "domain_suffix" | "suffix" => {
+                let mut s = g3_yaml::value::as_string(v)?;
+                if !s.is_empty() && !s.starts_with('.') {
+                    s.insert(0, '.');
+                }
+                self.domain_suffix = Some(s);
+                Ok(())
+            }
+            "global_label" => {
+                self.global_label = g3_yaml::value::as_string(v)?;
+                Ok(())
+            }
+            "http_port" => {
+                self.http_port = g3_yaml::value::as_u16(v)
+                    .context(format!("invalid u16 port value for key {k}"))?;
+                Ok(())
+            }
+            "socks5_port" | "socks_port" => {
+                self.socks5_port = g3_yaml::value::as_u16(v)
+                    .context(format!("invalid u16 port value for key {k}"))?;
+                Ok(())
+            }
+            "strip_suffix_for_auth" | "auth_strip_suffix" => {
+                self.strip_suffix_for_auth = g3_yaml::value::as_bool(v)?;
+                Ok(())
+            }
+            _ => Err(anyhow!("invalid key {k}")),
+        }
+    }
+
+    fn check(&mut self) -> anyhow::Result<()> {
+        if self.keys_for_host.iter().any(|k| k.is_empty()) {
+            return Err(anyhow!("keys_for_host contains empty key"));
+        }
+        if self.separator.is_empty() {
+            return Err(anyhow!("separator must not be empty"));
+        }
+        // ensure floating keys are included in keys_for_host
+        for fk in &self.floating_keys {
+            if !self.keys_for_host.iter().any(|k| k == fk) {
+                return Err(anyhow!("floating key {fk} must be listed in keys_for_host"));
+            }
+        }
+        Ok(())
+    }
+
+    pub(crate) fn suffix_for_host<'a>(&'a self, host: &'a str) -> Cow<'a, str> {
+        if let Some(sfx) = &self.domain_suffix {
+            if sfx.is_empty() {
+                Cow::Borrowed(host)
+            } else {
+                let mut s = String::with_capacity(host.len() + sfx.len());
+                s.push_str(host);
+                s.push_str(sfx);
+                Cow::Owned(s)
+            }
+        } else {
+            Cow::Borrowed(host)
+        }
+    }
+}

--- a/g3proxy/src/config/server/username_params_to_escaper.rs
+++ b/g3proxy/src/config/server/username_params_to_escaper.rs
@@ -27,8 +27,6 @@ pub(crate) struct UsernameParamsToEscaperConfig {
     pub(crate) separator: String,
     /// optional domain suffix appended to computed host (e.g., ".svc.local")
     pub(crate) domain_suffix: Option<String>,
-    /// label used when 0 kv pairs (global)
-    pub(crate) global_label: String,
     /// default port for HTTP proxy upstream selection
     pub(crate) http_port: u16,
     /// default port for SOCKS5 proxy upstream selection
@@ -48,7 +46,6 @@ impl UsernameParamsToEscaperConfig {
             reject_duplicate_keys: true,
             separator: "-".to_string(),
             domain_suffix: None,
-            global_label: "global".to_string(),
             http_port: 10000,
             socks5_port: 10001,
             strip_suffix_for_auth: true,
@@ -72,7 +69,6 @@ mod tests {
           reject_duplicate_keys: false
           separator: ":"
           suffix: "svc.local"
-          global_label: "g"
           http_port: 20000
           socks_port: 20001
           auth_strip_suffix: false
@@ -89,7 +85,6 @@ mod tests {
         assert!(!c.reject_duplicate_keys);
         assert_eq!(c.separator, ":");
         assert_eq!(c.domain_suffix.as_deref(), Some(".svc.local"));
-        assert_eq!(c.global_label, "g");
         assert_eq!(c.http_port, 20000);
         assert_eq!(c.socks5_port, 20001);
         assert!(!c.strip_suffix_for_auth);
@@ -173,10 +168,6 @@ impl UsernameParamsToEscaperConfig {
                     s.insert(0, '.');
                 }
                 self.domain_suffix = Some(s);
-                Ok(())
-            }
-            "global_label" => {
-                self.global_label = g3_yaml::value::as_string(v)?;
                 Ok(())
             }
             "http_port" => {

--- a/g3proxy/src/config/server/username_params_to_escaper.rs
+++ b/g3proxy/src/config/server/username_params_to_escaper.rs
@@ -96,14 +96,14 @@ mod tests {
     }
 
     #[test]
-    fn suffix_for_host_works() {
+    fn to_fqdn_works() {
         let mut c = UsernameParamsToEscaperConfig::new(None);
         // no suffix
-        assert_eq!(c.suffix_for_host("foo").as_ref(), "foo");
+        assert_eq!(c.to_fqdn("foo").as_ref(), "foo");
 
         // with suffix
         c.domain_suffix = Some(".example".to_string());
-        assert_eq!(c.suffix_for_host("foo").as_ref(), "foo.example");
+        assert_eq!(c.to_fqdn("foo").as_ref(), "foo.example");
 
         // suffix normalized from non-dot value
         let s = r#"
@@ -201,9 +201,7 @@ impl UsernameParamsToEscaperConfig {
         if self.keys_for_host.iter().any(|k| k.is_empty()) {
             return Err(anyhow!("keys_for_host contains empty key"));
         }
-        if self.separator.is_empty() {
-            return Err(anyhow!("separator must not be empty"));
-        }
+        // allow empty separator when only one label or when explicitly desired
         // ensure floating keys are included in keys_for_host
         for fk in &self.floating_keys {
             if !self.keys_for_host.iter().any(|k| k == fk) {
@@ -213,7 +211,7 @@ impl UsernameParamsToEscaperConfig {
         Ok(())
     }
 
-    pub(crate) fn suffix_for_host<'a>(&'a self, host: &'a str) -> Cow<'a, str> {
+    pub(crate) fn to_fqdn<'a>(&'a self, host: &'a str) -> Cow<'a, str> {
         if let Some(sfx) = &self.domain_suffix {
             if sfx.is_empty() {
                 Cow::Borrowed(host)

--- a/g3proxy/src/config/sticky.rs
+++ b/g3proxy/src/config/sticky.rs
@@ -1,0 +1,64 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+use std::path::Path;
+
+use anyhow::anyhow;
+use yaml_rust::Yaml;
+
+pub(crate) fn load(v: &Yaml, _conf_dir: &Path) -> anyhow::Result<()> {
+    match v {
+        Yaml::String(s) => {
+            crate::sticky::set_redis_url(Some(s));
+            Ok(())
+        }
+        Yaml::Hash(map) => {
+            let mut url: Option<String> = None;
+            let mut prefix: Option<String> = None;
+            let mut default_ttl: Option<std::time::Duration> = None;
+            let mut max_ttl: Option<std::time::Duration> = None;
+            g3_yaml::foreach_kv(map, |k, v| match g3_yaml::key::normalize(k).as_str() {
+                "url" | "redis" => {
+                    if let Yaml::String(s) = v {
+                        url = Some(s.clone());
+                        Ok(())
+                    } else {
+                        Err(anyhow!("invalid sticky redis url value"))
+                    }
+                }
+                "prefix" => {
+                    if let Yaml::String(s) = v {
+                        prefix = Some(s.clone());
+                        Ok(())
+                    } else {
+                        Err(anyhow!("invalid sticky prefix value"))
+                    }
+                }
+                "default_ttl" | "default" => {
+                    let d = g3_yaml::humanize::as_duration(v)
+                        .map_err(|_| anyhow!("invalid sticky default_ttl value"))?;
+                    default_ttl = Some(d);
+                    Ok(())
+                }
+                "max_ttl" | "maximum_ttl" => {
+                    let d = g3_yaml::humanize::as_duration(v)
+                        .map_err(|_| anyhow!("invalid sticky max_ttl value"))?;
+                    max_ttl = Some(d);
+                    Ok(())
+                }
+                _ => Ok(()),
+            })?;
+            if let Some(u) = url.as_deref() {
+                crate::sticky::set_redis_url(Some(u));
+            }
+            if let Some(p) = prefix.as_deref() {
+                crate::sticky::set_prefix(Some(p));
+            }
+            if let Some(d) = default_ttl { crate::sticky::set_default_ttl(Some(d)); }
+            if let Some(d) = max_ttl { crate::sticky::set_max_ttl(Some(d)); }
+            Ok(())
+        }
+        _ => Err(anyhow!("invalid sticky config value")),
+    }
+}

--- a/g3proxy/src/escape/direct_fixed/stats.rs
+++ b/g3proxy/src/escape/direct_fixed/stats.rs
@@ -29,6 +29,10 @@ pub(crate) struct DirectFixedEscaperStats {
     pub(crate) interface: EscaperInterfaceStats,
     pub(crate) udp: EscaperUdpStats,
     pub(crate) tcp: EscaperTcpStats,
+    // sticky metrics
+    sticky_hit: std::sync::atomic::AtomicU64,
+    sticky_miss: std::sync::atomic::AtomicU64,
+    sticky_set: std::sync::atomic::AtomicU64,
 }
 
 impl DirectFixedEscaperStats {
@@ -41,6 +45,9 @@ impl DirectFixedEscaperStats {
             interface: Default::default(),
             udp: Default::default(),
             tcp: Default::default(),
+            sticky_hit: Default::default(),
+            sticky_miss: Default::default(),
+            sticky_set: Default::default(),
         }
     }
 
@@ -197,5 +204,17 @@ impl UdpConnectTaskRemoteStats for DirectFixedEscaperStats {
 
     fn add_send_packets(&self, n: usize) {
         self.udp.io.add_out_packets(n);
+    }
+}
+
+impl DirectFixedEscaperStats {
+    pub(crate) fn add_sticky_hit(&self) {
+        self.sticky_hit.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    }
+    pub(crate) fn add_sticky_miss(&self) {
+        self.sticky_miss.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    }
+    pub(crate) fn add_sticky_set(&self) {
+        self.sticky_set.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
     }
 }

--- a/g3proxy/src/escape/direct_fixed/udp_connect/mod.rs
+++ b/g3proxy/src/escape/direct_fixed/udp_connect/mod.rs
@@ -120,9 +120,22 @@ impl DirectFixedEscaper {
             wrapper_stats,
         );
 
+        let send = if let Some(decision) = task_notes.sticky()
+            && decision.enabled()
+            && !decision.rotate
+        {
+            let key = crate::sticky::build_sticky_key(decision, task_conf.upstream);
+            let ttl = decision.effective_ttl();
+            Box::new(DirectUdpConnectRemoteSend::new_with_sticky(send, key, ttl))
+                as Box<dyn g3_io_ext::UdpCopyRemoteSend + Unpin + Send + Sync>
+        } else {
+            Box::new(DirectUdpConnectRemoteSend::new(send))
+                as Box<dyn g3_io_ext::UdpCopyRemoteSend + Unpin + Send + Sync>
+        };
+
         Ok((
             Box::new(DirectUdpConnectRemoteRecv::new(recv)),
-            Box::new(DirectUdpConnectRemoteSend::new(send)),
+            send,
             self.escape_logger.clone(),
         ))
     }

--- a/g3proxy/src/escape/direct_fixed/udp_relay/mod.rs
+++ b/g3proxy/src/escape/direct_fixed/udp_relay/mod.rs
@@ -42,6 +42,8 @@ impl DirectFixedEscaper {
             &self.egress_net_filter,
             &self.resolver_handle,
             self.config.resolve_strategy,
+            task_notes.sticky().cloned(),
+            self.config.happy_eyeballs.resolution_delay(),
         );
 
         if !self.config.no_ipv4 {

--- a/g3proxy/src/escape/direct_fixed/udp_relay/send.rs
+++ b/g3proxy/src/escape/direct_fixed/udp_relay/send.rs
@@ -159,17 +159,27 @@ where
                                     let stats = self.escaper_stats.clone();
                                     let delay = self.resolution_delay;
                                     tokio::spawn(async move {
-                                        if let Ok(mut job) = HappyEyeballsResolveJob::new_dyn(strategy, &resolver, d.clone()) {
-                                            if let Ok(ips) = job.get_r1_or_first(delay, usize::MAX).await {
-                                                if let Some((hrw_ip, key, hit)) = crate::sticky::choose_sticky_ip(&s, &upstream, &ips).await {
-                                                    if hit { stats.add_sticky_hit(); } else { stats.add_sticky_miss(); }
-                                                    if hit {
-                                                        crate::sticky::redis_refresh_ttl(&key, s.effective_ttl()).await;
-                                                    } else {
-                                                        crate::sticky::redis_set_ip(&key, hrw_ip, s.effective_ttl()).await;
-                                                        stats.add_sticky_set();
-                                                    }
-                                                }
+                                        if let Ok(mut job) = HappyEyeballsResolveJob::new_dyn(
+                                            strategy,
+                                            &resolver,
+                                            d.clone(),
+                                        )
+                                        && let Ok(ips) = job
+                                            .get_r1_or_first(delay, usize::MAX)
+                                            .await
+                                        && let Some((hrw_ip, key, hit)) = crate::sticky::choose_sticky_ip(
+                                            &s,
+                                            &upstream,
+                                            &ips,
+                                        )
+                                        .await
+                                        {
+                                            if hit { stats.add_sticky_hit(); } else { stats.add_sticky_miss(); }
+                                            if hit {
+                                                crate::sticky::redis_refresh_ttl(&key, s.effective_ttl()).await;
+                                            } else {
+                                                crate::sticky::redis_set_ip(&key, hrw_ip, s.effective_ttl()).await;
+                                                stats.add_sticky_set();
                                             }
                                         }
                                     });

--- a/g3proxy/src/escape/direct_float/tcp_connect/mod.rs
+++ b/g3proxy/src/escape/direct_float/tcp_connect/mod.rs
@@ -109,7 +109,7 @@ impl DirectFloatEscaper {
         task_notes: &ServerTaskNotes,
     ) -> Result<(TcpStream, DirectFloatBindIp), TcpConnectError> {
         let (sock, bind) =
-            self.prepare_connect_socket(peer_ip, tcp_notes.bind, task_notes, &config)?;
+            self.prepare_connect_socket(peer_ip, tcp_notes.bind, task_notes, config)?;
         let peer = SocketAddr::new(peer_ip, task_conf.upstream.port());
         tcp_notes.next = Some(peer);
         tcp_notes.bind = BindAddr::Ip(bind.ip);

--- a/g3proxy/src/escape/direct_float/udp_relay/mod.rs
+++ b/g3proxy/src/escape/direct_float/udp_relay/mod.rs
@@ -47,28 +47,25 @@ impl DirectFloatEscaper {
         if let Some(decision) = task_notes.sticky()
             && decision.enabled()
             && !decision.rotate
-            && matches!(task_conf.initial_peer.host(), g3_types::net::Host::Domain(_))
+            && let g3_types::net::Host::Domain(domain) = task_conf.initial_peer.host()
         {
-            if let g3_types::net::Host::Domain(domain) = task_conf.initial_peer.host() {
-                let mut resolver_job =
-                    crate::resolve::HappyEyeballsResolveJob::new_dyn(
-                        self.config.resolve_strategy,
-                        &self.resolver_handle,
-                        domain.clone(),
-                    )?;
-                let ips = resolver_job
-                    .get_r1_or_first(self.config.happy_eyeballs.resolution_delay(), usize::MAX)
-                    .await?;
-                if let Some((ip, key, cache_hit)) =
-                    crate::sticky::choose_sticky_ip(decision, task_conf.initial_peer, &ips).await
-                {
-                    if cache_hit { self.stats.add_sticky_hit(); } else { self.stats.add_sticky_miss(); }
-                    send.prime_domain_ip(domain.clone(), ip);
-                    // set TTL now for the session
-                    let ttl = decision.effective_ttl();
-                    crate::sticky::redis_set_ip(&key, ip, ttl).await;
-                    self.stats.add_sticky_set();
-                }
+            let mut resolver_job = crate::resolve::HappyEyeballsResolveJob::new_dyn(
+                self.config.resolve_strategy,
+                &self.resolver_handle,
+                domain.clone(),
+            )?;
+            let ips = resolver_job
+                .get_r1_or_first(self.config.happy_eyeballs.resolution_delay(), usize::MAX)
+                .await?;
+            if let Some((ip, key, cache_hit)) =
+                crate::sticky::choose_sticky_ip(decision, task_conf.initial_peer, &ips).await
+            {
+                if cache_hit { self.stats.add_sticky_hit(); } else { self.stats.add_sticky_miss(); }
+                send.prime_domain_ip(domain.clone(), ip);
+                // set TTL now for the session
+                let ttl = decision.effective_ttl();
+                crate::sticky::redis_set_ip(&key, ip, ttl).await;
+                self.stats.add_sticky_set();
             }
         }
 

--- a/g3proxy/src/escape/divert_tcp/tcp_connect/mod.rs
+++ b/g3proxy/src/escape/divert_tcp/tcp_connect/mod.rs
@@ -306,7 +306,10 @@ impl DivertTcpEscaper {
         tcp_notes: &mut TcpConnectTaskNotes,
         task_notes: &ServerTaskNotes,
     ) -> Result<TcpStream, TcpConnectError> {
-        let peer_proxy = self.get_next_proxy(task_notes, task_conf.upstream.host());
+        let peer_proxy = task_notes
+            .override_next_proxy()
+            .cloned()
+            .unwrap_or_else(|| self.get_next_proxy(task_notes, task_conf.upstream.host()).clone());
 
         match peer_proxy.host() {
             Host::Ip(ip) => {

--- a/g3proxy/src/escape/divert_tcp/tcp_connect/mod.rs
+++ b/g3proxy/src/escape/divert_tcp/tcp_connect/mod.rs
@@ -13,7 +13,7 @@ use tokio::time::Instant;
 use g3_daemon::stat::remote::{ArcTcpConnectionTaskRemoteStats, TcpConnectionTaskRemoteStats};
 use g3_io_ext::{LimitedReader, LimitedWriter};
 use g3_socket::BindAddr;
-use g3_types::net::{ConnectError, Host};
+use g3_types::net::ConnectError;
 
 use super::DivertTcpEscaper;
 use crate::log::escape::tcp_connect::EscapeLogForTcpConnect;
@@ -300,30 +300,25 @@ impl DivertTcpEscaper {
         }
     }
 
-    pub(super) async fn tcp_connect_to(
+    async fn connect_via_peer(
         &self,
+        peer_proxy: &g3_types::net::UpstreamAddr,
         task_conf: &TcpConnectTaskConf<'_>,
         tcp_notes: &mut TcpConnectTaskNotes,
         task_notes: &ServerTaskNotes,
     ) -> Result<TcpStream, TcpConnectError> {
-        let peer_proxy = task_notes
-            .override_next_proxy()
-            .cloned()
-            .unwrap_or_else(|| self.get_next_proxy(task_notes, task_conf.upstream.host()).clone());
-
         match peer_proxy.host() {
-            Host::Ip(ip) => {
+            g3_types::net::Host::Ip(ip) => {
                 self.fixed_try_connect(
-                    SocketAddr::new(*ip, peer_proxy.port()),
+                    std::net::SocketAddr::new(*ip, peer_proxy.port()),
                     task_conf,
                     tcp_notes,
                     task_notes,
                 )
                 .await
             }
-            Host::Domain(domain) => {
+            g3_types::net::Host::Domain(domain) => {
                 let resolver_job = self.resolve_happy(domain.clone())?;
-
                 self.happy_try_connect(
                     resolver_job,
                     peer_proxy.port(),
@@ -334,6 +329,19 @@ impl DivertTcpEscaper {
                 .await
             }
         }
+    }
+
+    pub(super) async fn tcp_connect_to(
+        &self,
+        task_conf: &TcpConnectTaskConf<'_>,
+        tcp_notes: &mut TcpConnectTaskNotes,
+        task_notes: &ServerTaskNotes,
+    ) -> Result<TcpStream, TcpConnectError> {
+        let peer_proxy = self.get_next_proxy(task_notes, task_conf.upstream.host());
+
+        self
+            .connect_via_peer(peer_proxy, task_conf, tcp_notes, task_notes)
+            .await
     }
 
     pub(super) async fn tcp_new_connection(

--- a/g3proxy/src/escape/proxy_http/tcp_connect/mod.rs
+++ b/g3proxy/src/escape/proxy_http/tcp_connect/mod.rs
@@ -70,7 +70,7 @@ impl ProxyHttpEscaper {
         )
         .map_err(TcpConnectError::SetupSocketFailed)?;
         Ok((sock, bind))
-    }
+}
 
     async fn fixed_try_connect(
         &self,
@@ -307,15 +307,93 @@ impl ProxyHttpEscaper {
             .unwrap_or_else(|| self.get_next_proxy(task_notes, task_conf.upstream.host()));
         match peer_proxy.host() {
             g3_types::net::Host::Ip(ip) => {
-                self.fixed_try_connect(
-                    SocketAddr::new(*ip, peer_proxy.port()),
-                    task_conf,
-                    tcp_notes,
-                    task_notes,
-                )
-                .await
+                // If sticky is requested and proxy nodes are multiple static IPs, try HRW over the list
+                if let Some(decision) = task_notes.sticky()
+                    && decision.enabled()
+                    && !decision.rotate
+                    && self.static_proxy_ip_ports.len() >= 2
+                {
+                    let ips: Vec<IpAddr> =
+                        self.static_proxy_ip_ports.iter().map(|(ip, _)| *ip).collect();
+                    if let Some((pick, key, _hit)) =
+                        crate::sticky::choose_sticky_ip(decision, task_conf.upstream, &ips).await
+                    {
+                        let port = self
+                            .static_proxy_ip_ports
+                            .iter()
+                            .find_map(|(ipx, p)| if *ipx == pick { Some(*p) } else { None })
+                            .unwrap_or(peer_proxy.port());
+                        let peer = SocketAddr::new(pick, port);
+                        if let Ok(stream) =
+                            self.fixed_try_connect(peer, task_conf, tcp_notes, task_notes).await
+                        {
+                            // success: store mapping with TTL
+                            tcp_notes.sticky_enabled = true;
+                            let ttl = decision.effective_ttl();
+                            let now = chrono::Utc::now();
+                            tcp_notes.sticky_expires_at =
+                                Some(crate::sticky::compute_expiry(now, ttl));
+                            crate::sticky::redis_set_ip(&key, pick, ttl).await;
+                            return Ok(stream);
+                        }
+                    }
+                }
+
+                self
+                    .fixed_try_connect(
+                        SocketAddr::new(*ip, peer_proxy.port()),
+                        task_conf,
+                        tcp_notes,
+                        task_notes,
+                    )
+                    .await
             }
             g3_types::net::Host::Domain(domain) => {
+                // Try sticky selection if requested
+                if let Some(decision) = task_notes.sticky()
+                    && decision.enabled()
+                    && !decision.rotate
+                {
+                    let mut resolver_job = self.resolve_happy(domain.clone())?;
+                    // Use all resolved IPs for HRW selection to avoid bias
+                    let ips = resolver_job
+                        .get_r1_or_first(
+                            self.config.happy_eyeballs.resolution_delay(),
+                            usize::MAX,
+                        )
+                        .await?;
+                    if let Some((pick, key, _cache_hit)) =
+                        crate::sticky::choose_sticky_ip(decision, task_conf.upstream, &ips).await
+                    {
+                        // optimistically try picked IP first
+                        let peer = SocketAddr::new(pick, peer_proxy.port());
+                        if let Ok(stream) =
+                            self.fixed_try_connect(peer, task_conf, tcp_notes, task_notes).await
+                        {
+                            // mark sticky on success and set sliding TTL
+                            tcp_notes.sticky_enabled = true;
+                            let ttl = decision.effective_ttl();
+                            let now = chrono::Utc::now();
+                            tcp_notes.sticky_expires_at =
+                                Some(crate::sticky::compute_expiry(now, ttl));
+                            // store mapping; no-op if redis not configured
+                            crate::sticky::redis_set_ip(&key, pick, ttl).await;
+                            return Ok(stream);
+                        }
+                    }
+                    // rebuild a resolver job to proceed normal path
+                    let resolver_job = self.resolve_happy(domain.clone())?;
+                    return self
+                        .happy_try_connect(
+                            resolver_job,
+                            peer_proxy.port(),
+                            task_conf,
+                            tcp_notes,
+                            task_notes,
+                        )
+                        .await;
+                }
+
                 let resolver_job = self.resolve_happy(domain.clone())?;
                 self.happy_try_connect(
                     resolver_job,
@@ -360,5 +438,36 @@ impl ProxyHttpEscaper {
         }
 
         Ok(stream)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::sticky::{parse_username_and_decision, build_sticky_key};
+    use std::net::IpAddr;
+
+    #[test]
+    fn sticky_key_uses_target_upstream() {
+        let ups: g3_types::net::UpstreamAddr = "example.com:80".parse().unwrap();
+        let (_base, d) = parse_username_and_decision("alice+sticky=5m+session_id=cart1");
+        let k = build_sticky_key(&d, &ups);
+        assert!(k.contains("example.com:80"));
+        assert!(k.contains("|alice"));
+        assert!(k.contains("session_id=cart1"));
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn sticky_pick_is_member_of_ips() {
+        let ups: g3_types::net::UpstreamAddr = "example.com:80".parse().unwrap();
+        let (_base, d) = parse_username_and_decision("alice+session_id=cart1");
+        let ips: Vec<IpAddr> = vec![
+            "10.0.0.2".parse().unwrap(),
+            "10.0.0.3".parse().unwrap(),
+            "10.0.0.4".parse().unwrap(),
+        ];
+        let r = crate::sticky::choose_sticky_ip(&d, &ups, &ips).await;
+        assert!(r.is_some());
+        let (pick, _key, _hit) = r.unwrap();
+        assert!(ips.contains(&pick));
     }
 }

--- a/g3proxy/src/escape/proxy_http/tcp_connect/mod.rs
+++ b/g3proxy/src/escape/proxy_http/tcp_connect/mod.rs
@@ -302,7 +302,10 @@ impl ProxyHttpEscaper {
         tcp_notes: &mut TcpConnectTaskNotes,
         task_notes: &ServerTaskNotes,
     ) -> Result<TcpStream, TcpConnectError> {
-        let peer_proxy = self.get_next_proxy(task_notes, task_conf.upstream.host());
+        let peer_proxy = task_notes
+            .override_next_proxy()
+            .cloned()
+            .unwrap_or_else(|| self.get_next_proxy(task_notes, task_conf.upstream.host()).clone());
 
         match peer_proxy.host() {
             Host::Ip(ip) => {

--- a/g3proxy/src/escape/proxy_http/tcp_connect/mod.rs
+++ b/g3proxy/src/escape/proxy_http/tcp_connect/mod.rs
@@ -311,37 +311,36 @@ impl ProxyHttpEscaper {
                 if let Some(decision) = task_notes.sticky()
                     && decision.enabled()
                     && !decision.rotate
+                    && self.static_proxy_ip_ports.len() >= 2
                 {
-                    if self.static_proxy_ip_ports.len() >= 2 {
-                        let ips: Vec<IpAddr> =
-                            self.static_proxy_ip_ports.iter().map(|(ip, _)| *ip).collect();
-                        if let Some((pick, key, _hit)) =
-                            crate::sticky::choose_sticky_ip(decision, task_conf.upstream, &ips)
-                                .await
+                    let ips: Vec<IpAddr> =
+                        self.static_proxy_ip_ports.iter().map(|(ip, _)| *ip).collect();
+                    if let Some((pick, key, _hit)) =
+                        crate::sticky::choose_sticky_ip(decision, task_conf.upstream, &ips)
+                            .await
+                    {
+                        let port = self
+                            .static_proxy_ip_ports
+                            .iter()
+                            .find_map(|(ipx, p)| if *ipx == pick { Some(*p) } else { None })
+                            .unwrap_or(peer_proxy.port());
+                        let peer = SocketAddr::new(pick, port);
+                        match self
+                            .fixed_try_connect(peer, task_conf, tcp_notes, task_notes)
+                            .await
                         {
-                            let port = self
-                                .static_proxy_ip_ports
-                                .iter()
-                                .find_map(|(ipx, p)| if *ipx == pick { Some(*p) } else { None })
-                                .unwrap_or(peer_proxy.port());
-                            let peer = SocketAddr::new(pick, port);
-                            match self
-                                .fixed_try_connect(peer, task_conf, tcp_notes, task_notes)
-                                .await
-                            {
-                                Ok(stream) => {
-                                    // success: store mapping with TTL
-                                    tcp_notes.sticky_enabled = true;
-                                    let ttl = decision.effective_ttl();
-                                    let now = chrono::Utc::now();
-                                    tcp_notes.sticky_expires_at =
-                                        Some(crate::sticky::compute_expiry(now, ttl));
-                                    crate::sticky::redis_set_ip(&key, pick, ttl).await;
-                                    return Ok(stream);
-                                }
-                                Err(_) => {
-                                    // fall back to default chosen peer
-                                }
+                            Ok(stream) => {
+                                // success: store mapping with TTL
+                                tcp_notes.sticky_enabled = true;
+                                let ttl = decision.effective_ttl();
+                                let now = chrono::Utc::now();
+                                tcp_notes.sticky_expires_at =
+                                    Some(crate::sticky::compute_expiry(now, ttl));
+                                crate::sticky::redis_set_ip(&key, pick, ttl).await;
+                                return Ok(stream);
+                            }
+                            Err(_) => {
+                                // fall back to default chosen peer
                             }
                         }
                     }

--- a/g3proxy/src/escape/proxy_http/tcp_connect/mod.rs
+++ b/g3proxy/src/escape/proxy_http/tcp_connect/mod.rs
@@ -12,7 +12,7 @@ use tokio::time::Instant;
 
 use g3_io_ext::LimitedStream;
 use g3_socket::BindAddr;
-use g3_types::net::{ConnectError, Host, ProxyProtocolEncoder};
+use g3_types::net::{ConnectError, ProxyProtocolEncoder};
 
 use super::ProxyHttpEscaper;
 use crate::log::escape::tcp_connect::EscapeLogForTcpConnect;
@@ -296,30 +296,25 @@ impl ProxyHttpEscaper {
         }
     }
 
-    async fn tcp_connect_to(
+    async fn connect_via_peer(
         &self,
+        peer_proxy: &g3_types::net::UpstreamAddr,
         task_conf: &TcpConnectTaskConf<'_>,
         tcp_notes: &mut TcpConnectTaskNotes,
         task_notes: &ServerTaskNotes,
     ) -> Result<TcpStream, TcpConnectError> {
-        let peer_proxy = task_notes
-            .override_next_proxy()
-            .cloned()
-            .unwrap_or_else(|| self.get_next_proxy(task_notes, task_conf.upstream.host()).clone());
-
         match peer_proxy.host() {
-            Host::Ip(ip) => {
+            g3_types::net::Host::Ip(ip) => {
                 self.fixed_try_connect(
-                    SocketAddr::new(*ip, peer_proxy.port()),
+                    std::net::SocketAddr::new(*ip, peer_proxy.port()),
                     task_conf,
                     tcp_notes,
                     task_notes,
                 )
                 .await
             }
-            Host::Domain(domain) => {
+            g3_types::net::Host::Domain(domain) => {
                 let resolver_job = self.resolve_happy(domain.clone())?;
-
                 self.happy_try_connect(
                     resolver_job,
                     peer_proxy.port(),
@@ -330,6 +325,21 @@ impl ProxyHttpEscaper {
                 .await
             }
         }
+    }
+
+    async fn tcp_connect_to(
+        &self,
+        task_conf: &TcpConnectTaskConf<'_>,
+        tcp_notes: &mut TcpConnectTaskNotes,
+        task_notes: &ServerTaskNotes,
+    ) -> Result<TcpStream, TcpConnectError> {
+        let peer_proxy = task_notes
+            .override_next_proxy()
+            .unwrap_or_else(|| self.get_next_proxy(task_notes, task_conf.upstream.host()));
+
+        self
+            .connect_via_peer(peer_proxy, task_conf, tcp_notes, task_notes)
+            .await
     }
 
     pub(super) async fn tcp_new_connection(

--- a/g3proxy/src/escape/proxy_https/tcp_connect/mod.rs
+++ b/g3proxy/src/escape/proxy_https/tcp_connect/mod.rs
@@ -302,9 +302,10 @@ impl ProxyHttpsEscaper {
         tcp_notes: &mut TcpConnectTaskNotes,
         task_notes: &ServerTaskNotes,
     ) -> Result<(UpstreamAddr, TcpStream), TcpConnectError> {
-        let peer_proxy = self
-            .get_next_proxy(task_notes, task_conf.upstream.host())
-            .clone();
+        let peer_proxy = task_notes
+            .override_next_proxy()
+            .cloned()
+            .unwrap_or_else(|| self.get_next_proxy(task_notes, task_conf.upstream.host()).clone());
 
         let stream = match peer_proxy.host() {
             Host::Ip(ip) => {

--- a/g3proxy/src/escape/proxy_https/tcp_connect/mod.rs
+++ b/g3proxy/src/escape/proxy_https/tcp_connect/mod.rs
@@ -298,37 +298,6 @@ impl ProxyHttpsEscaper {
 
     async fn connect_via_peer(
         &self,
-        peer_proxy: &g3_types::net::UpstreamAddr,
-        task_conf: &TcpConnectTaskConf<'_>,
-        tcp_notes: &mut TcpConnectTaskNotes,
-        task_notes: &ServerTaskNotes,
-    ) -> Result<TcpStream, TcpConnectError> {
-        match peer_proxy.host() {
-            g3_types::net::Host::Ip(ip) => {
-                self.fixed_try_connect(
-                    std::net::SocketAddr::new(*ip, peer_proxy.port()),
-                    task_conf,
-                    tcp_notes,
-                    task_notes,
-                )
-                .await
-            }
-            g3_types::net::Host::Domain(domain) => {
-                let resolver_job = self.resolve_happy(domain.clone())?;
-                self.happy_try_connect(
-                    resolver_job,
-                    peer_proxy.port(),
-                    task_conf,
-                    tcp_notes,
-                    task_notes,
-                )
-                .await
-            }
-        }
-    }
-
-    async fn tcp_connect_to(
-        &self,
         task_conf: &TcpConnectTaskConf<'_>,
         tcp_notes: &mut TcpConnectTaskNotes,
         task_notes: &ServerTaskNotes,
@@ -336,12 +305,30 @@ impl ProxyHttpsEscaper {
         let peer_proxy = task_notes
             .override_next_proxy()
             .unwrap_or_else(|| self.get_next_proxy(task_notes, task_conf.upstream.host()));
-
-        let stream = self
-            .connect_via_peer(peer_proxy, task_conf, tcp_notes, task_notes)
-            .await?;
-
-        Ok((peer_proxy.clone(), stream))
+        match peer_proxy.host() {
+            g3_types::net::Host::Ip(ip) => {
+                let stream = self.fixed_try_connect(
+                    SocketAddr::new(*ip, peer_proxy.port()),
+                    task_conf,
+                    tcp_notes,
+                    task_notes,
+                )
+                .await?;
+                Ok((peer_proxy.clone(), stream))
+            }
+            g3_types::net::Host::Domain(domain) => {
+                let resolver_job = self.resolve_happy(domain.clone())?;
+                let stream = self.happy_try_connect(
+                    resolver_job,
+                    peer_proxy.port(),
+                    task_conf,
+                    tcp_notes,
+                    task_notes,
+                )
+                .await?;
+                Ok((peer_proxy.clone(), stream))
+            }
+        }
     }
 
     pub(super) async fn tcp_new_connection(
@@ -351,7 +338,7 @@ impl ProxyHttpsEscaper {
         task_notes: &ServerTaskNotes,
     ) -> Result<(UpstreamAddr, LimitedStream<TcpStream>), TcpConnectError> {
         let (peer, stream) = self
-            .tcp_connect_to(task_conf, tcp_notes, task_notes)
+            .connect_via_peer(task_conf, tcp_notes, task_notes)
             .await?;
 
         let limit_config = &self.config.general.tcp_sock_speed_limit;

--- a/g3proxy/src/escape/proxy_https/tcp_connect/mod.rs
+++ b/g3proxy/src/escape/proxy_https/tcp_connect/mod.rs
@@ -12,7 +12,7 @@ use tokio::time::Instant;
 
 use g3_io_ext::LimitedStream;
 use g3_socket::BindAddr;
-use g3_types::net::{ConnectError, Host, ProxyProtocolEncoder, UpstreamAddr};
+use g3_types::net::{ConnectError, ProxyProtocolEncoder, UpstreamAddr};
 
 use super::ProxyHttpsEscaper;
 use crate::log::escape::tcp_connect::EscapeLogForTcpConnect;
@@ -296,6 +296,37 @@ impl ProxyHttpsEscaper {
         }
     }
 
+    async fn connect_via_peer(
+        &self,
+        peer_proxy: &g3_types::net::UpstreamAddr,
+        task_conf: &TcpConnectTaskConf<'_>,
+        tcp_notes: &mut TcpConnectTaskNotes,
+        task_notes: &ServerTaskNotes,
+    ) -> Result<TcpStream, TcpConnectError> {
+        match peer_proxy.host() {
+            g3_types::net::Host::Ip(ip) => {
+                self.fixed_try_connect(
+                    std::net::SocketAddr::new(*ip, peer_proxy.port()),
+                    task_conf,
+                    tcp_notes,
+                    task_notes,
+                )
+                .await
+            }
+            g3_types::net::Host::Domain(domain) => {
+                let resolver_job = self.resolve_happy(domain.clone())?;
+                self.happy_try_connect(
+                    resolver_job,
+                    peer_proxy.port(),
+                    task_conf,
+                    tcp_notes,
+                    task_notes,
+                )
+                .await
+            }
+        }
+    }
+
     async fn tcp_connect_to(
         &self,
         task_conf: &TcpConnectTaskConf<'_>,
@@ -304,34 +335,13 @@ impl ProxyHttpsEscaper {
     ) -> Result<(UpstreamAddr, TcpStream), TcpConnectError> {
         let peer_proxy = task_notes
             .override_next_proxy()
-            .cloned()
-            .unwrap_or_else(|| self.get_next_proxy(task_notes, task_conf.upstream.host()).clone());
+            .unwrap_or_else(|| self.get_next_proxy(task_notes, task_conf.upstream.host()));
 
-        let stream = match peer_proxy.host() {
-            Host::Ip(ip) => {
-                self.fixed_try_connect(
-                    SocketAddr::new(*ip, peer_proxy.port()),
-                    task_conf,
-                    tcp_notes,
-                    task_notes,
-                )
-                .await?
-            }
-            Host::Domain(domain) => {
-                let resolver_job = self.resolve_happy(domain.clone())?;
+        let stream = self
+            .connect_via_peer(peer_proxy, task_conf, tcp_notes, task_notes)
+            .await?;
 
-                self.happy_try_connect(
-                    resolver_job,
-                    peer_proxy.port(),
-                    task_conf,
-                    tcp_notes,
-                    task_notes,
-                )
-                .await?
-            }
-        };
-
-        Ok((peer_proxy, stream))
+        Ok((peer_proxy.clone(), stream))
     }
 
     pub(super) async fn tcp_new_connection(

--- a/g3proxy/src/escape/proxy_socks5/tcp_connect/mod.rs
+++ b/g3proxy/src/escape/proxy_socks5/tcp_connect/mod.rs
@@ -11,7 +11,7 @@ use tokio::time::Instant;
 
 use g3_io_ext::LimitedStream;
 use g3_socket::BindAddr;
-use g3_types::net::{ConnectError, Host};
+use g3_types::net::ConnectError;
 
 use super::ProxySocks5Escaper;
 use crate::log::escape::tcp_connect::EscapeLogForTcpConnect;
@@ -295,30 +295,25 @@ impl ProxySocks5Escaper {
         }
     }
 
-    async fn tcp_connect_to(
+    async fn connect_via_peer(
         &self,
+        peer_proxy: &g3_types::net::UpstreamAddr,
         task_conf: &TcpConnectTaskConf<'_>,
         tcp_notes: &mut TcpConnectTaskNotes,
         task_notes: &ServerTaskNotes,
     ) -> Result<TcpStream, TcpConnectError> {
-        let peer_proxy = task_notes
-            .override_next_proxy()
-            .cloned()
-            .unwrap_or_else(|| self.get_next_proxy(task_notes, task_conf.upstream.host()).clone());
-
         match peer_proxy.host() {
-            Host::Ip(ip) => {
+            g3_types::net::Host::Ip(ip) => {
                 self.fixed_try_connect(
-                    SocketAddr::new(*ip, peer_proxy.port()),
+                    std::net::SocketAddr::new(*ip, peer_proxy.port()),
                     task_conf,
                     tcp_notes,
                     task_notes,
                 )
                 .await
             }
-            Host::Domain(domain) => {
+            g3_types::net::Host::Domain(domain) => {
                 let resolver_job = self.resolve_happy(domain.clone())?;
-
                 self.happy_try_connect(
                     resolver_job,
                     peer_proxy.port(),
@@ -329,6 +324,21 @@ impl ProxySocks5Escaper {
                 .await
             }
         }
+    }
+
+    async fn tcp_connect_to(
+        &self,
+        task_conf: &TcpConnectTaskConf<'_>,
+        tcp_notes: &mut TcpConnectTaskNotes,
+        task_notes: &ServerTaskNotes,
+    ) -> Result<TcpStream, TcpConnectError> {
+        let peer_proxy = task_notes
+            .override_next_proxy()
+            .unwrap_or_else(|| self.get_next_proxy(task_notes, task_conf.upstream.host()));
+
+        self
+            .connect_via_peer(peer_proxy, task_conf, tcp_notes, task_notes)
+            .await
     }
 
     pub(super) async fn tcp_new_connection(

--- a/g3proxy/src/escape/proxy_socks5/tcp_connect/mod.rs
+++ b/g3proxy/src/escape/proxy_socks5/tcp_connect/mod.rs
@@ -69,7 +69,7 @@ impl ProxySocks5Escaper {
         )
         .map_err(TcpConnectError::SetupSocketFailed)?;
         Ok((sock, bind))
-    }
+}
 
     async fn fixed_try_connect(
         &self,
@@ -306,15 +306,89 @@ impl ProxySocks5Escaper {
             .unwrap_or_else(|| self.get_next_proxy(task_notes, task_conf.upstream.host()));
         match peer_proxy.host() {
             g3_types::net::Host::Ip(ip) => {
-                self.fixed_try_connect(
-                    SocketAddr::new(*ip, peer_proxy.port()),
-                    task_conf,
-                    tcp_notes,
-                    task_notes,
-                )
-                .await
+                // If there are multiple static proxy IPs configured, try sticky selection
+                if let Some(decision) = task_notes.sticky()
+                    && decision.enabled()
+                    && !decision.rotate
+                    && self.static_proxy_ip_ports.len() >= 2
+                {
+                    let ips: Vec<IpAddr> =
+                        self.static_proxy_ip_ports.iter().map(|(ip, _)| *ip).collect();
+                    if let Some((pick, key, _hit)) =
+                        crate::sticky::choose_sticky_ip(decision, task_conf.upstream, &ips).await
+                    {
+                        let port = self
+                            .static_proxy_ip_ports
+                            .iter()
+                            .find_map(|(ipx, p)| if *ipx == pick { Some(*p) } else { None })
+                            .unwrap_or(peer_proxy.port());
+                        let peer = SocketAddr::new(pick, port);
+                        if let Ok(stream) =
+                            self.fixed_try_connect(peer, task_conf, tcp_notes, task_notes).await
+                        {
+                            tcp_notes.sticky_enabled = true;
+                            let ttl = decision.effective_ttl();
+                            let now = chrono::Utc::now();
+                            tcp_notes.sticky_expires_at =
+                                Some(crate::sticky::compute_expiry(now, ttl));
+                            crate::sticky::redis_set_ip(&key, pick, ttl).await;
+                            return Ok(stream);
+                        }
+                    }
+                }
+
+                self
+                    .fixed_try_connect(
+                        SocketAddr::new(*ip, peer_proxy.port()),
+                        task_conf,
+                        tcp_notes,
+                        task_notes,
+                    )
+                    .await
             }
             g3_types::net::Host::Domain(domain) => {
+                // Try sticky selection if requested
+                if let Some(decision) = task_notes.sticky()
+                    && decision.enabled()
+                    && !decision.rotate
+                {
+                    let mut resolver_job = self.resolve_happy(domain.clone())?;
+                    // Use all resolved IPs for HRW selection to avoid bias
+                    let ips = resolver_job
+                        .get_r1_or_first(
+                            self.config.happy_eyeballs.resolution_delay(),
+                            usize::MAX,
+                        )
+                        .await?;
+                    if let Some((pick, key, _cache_hit)) =
+                        crate::sticky::choose_sticky_ip(decision, task_conf.upstream, &ips).await
+                    {
+                        let peer = SocketAddr::new(pick, peer_proxy.port());
+                        if let Ok(stream) =
+                            self.fixed_try_connect(peer, task_conf, tcp_notes, task_notes).await
+                        {
+                            tcp_notes.sticky_enabled = true;
+                            let ttl = decision.effective_ttl();
+                            let now = chrono::Utc::now();
+                            tcp_notes.sticky_expires_at =
+                                Some(crate::sticky::compute_expiry(now, ttl));
+                            crate::sticky::redis_set_ip(&key, pick, ttl).await;
+                            return Ok(stream);
+                        }
+                    }
+                    // rebuild to proceed normal path
+                    let resolver_job = self.resolve_happy(domain.clone())?;
+                    return self
+                        .happy_try_connect(
+                            resolver_job,
+                            peer_proxy.port(),
+                            task_conf,
+                            tcp_notes,
+                            task_notes,
+                        )
+                        .await;
+                }
+
                 let resolver_job = self.resolve_happy(domain.clone())?;
                 self.happy_try_connect(
                     resolver_job,
@@ -348,5 +422,35 @@ impl ProxySocks5Escaper {
         );
 
         Ok(stream)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::sticky::{parse_username_and_decision, build_sticky_key};
+    use std::net::IpAddr;
+
+    #[test]
+    fn sticky_key_contains_target() {
+        let ups: g3_types::net::UpstreamAddr = "example.com:443".parse().unwrap();
+        let (_base, d) = parse_username_and_decision("u+session_id=s1");
+        let k = build_sticky_key(&d, &ups);
+        assert!(k.contains("example.com:443"));
+        assert!(k.contains("|u"));
+        assert!(k.contains("session_id=s1"));
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn sticky_pick_from_list() {
+        let ups: g3_types::net::UpstreamAddr = "example.org:1080".parse().unwrap();
+        let (_base, d) = parse_username_and_decision("u+sticky=30s");
+        let ips: Vec<IpAddr> = vec![
+            "192.0.2.10".parse().unwrap(),
+            "192.0.2.11".parse().unwrap(),
+        ];
+        let r = crate::sticky::choose_sticky_ip(&d, &ups, &ips).await;
+        assert!(r.is_some());
+        let (pick, _key, _hit) = r.unwrap();
+        assert!(ips.contains(&pick));
     }
 }

--- a/g3proxy/src/escape/proxy_socks5/tcp_connect/mod.rs
+++ b/g3proxy/src/escape/proxy_socks5/tcp_connect/mod.rs
@@ -301,7 +301,10 @@ impl ProxySocks5Escaper {
         tcp_notes: &mut TcpConnectTaskNotes,
         task_notes: &ServerTaskNotes,
     ) -> Result<TcpStream, TcpConnectError> {
-        let peer_proxy = self.get_next_proxy(task_notes, task_conf.upstream.host());
+        let peer_proxy = task_notes
+            .override_next_proxy()
+            .cloned()
+            .unwrap_or_else(|| self.get_next_proxy(task_notes, task_conf.upstream.host()).clone());
 
         match peer_proxy.host() {
             Host::Ip(ip) => {

--- a/g3proxy/src/escape/proxy_socks5/tcp_connect/mod.rs
+++ b/g3proxy/src/escape/proxy_socks5/tcp_connect/mod.rs
@@ -297,15 +297,17 @@ impl ProxySocks5Escaper {
 
     async fn connect_via_peer(
         &self,
-        peer_proxy: &g3_types::net::UpstreamAddr,
         task_conf: &TcpConnectTaskConf<'_>,
         tcp_notes: &mut TcpConnectTaskNotes,
         task_notes: &ServerTaskNotes,
     ) -> Result<TcpStream, TcpConnectError> {
+        let peer_proxy = task_notes
+            .override_next_proxy()
+            .unwrap_or_else(|| self.get_next_proxy(task_notes, task_conf.upstream.host()));
         match peer_proxy.host() {
             g3_types::net::Host::Ip(ip) => {
                 self.fixed_try_connect(
-                    std::net::SocketAddr::new(*ip, peer_proxy.port()),
+                    SocketAddr::new(*ip, peer_proxy.port()),
                     task_conf,
                     tcp_notes,
                     task_notes,
@@ -326,21 +328,6 @@ impl ProxySocks5Escaper {
         }
     }
 
-    async fn tcp_connect_to(
-        &self,
-        task_conf: &TcpConnectTaskConf<'_>,
-        tcp_notes: &mut TcpConnectTaskNotes,
-        task_notes: &ServerTaskNotes,
-    ) -> Result<TcpStream, TcpConnectError> {
-        let peer_proxy = task_notes
-            .override_next_proxy()
-            .unwrap_or_else(|| self.get_next_proxy(task_notes, task_conf.upstream.host()));
-
-        self
-            .connect_via_peer(peer_proxy, task_conf, tcp_notes, task_notes)
-            .await
-    }
-
     pub(super) async fn tcp_new_connection(
         &self,
         task_conf: &TcpConnectTaskConf<'_>,
@@ -348,7 +335,7 @@ impl ProxySocks5Escaper {
         task_notes: &ServerTaskNotes,
     ) -> Result<LimitedStream<TcpStream>, TcpConnectError> {
         let stream = self
-            .tcp_connect_to(task_conf, tcp_notes, task_notes)
+            .connect_via_peer(task_conf, tcp_notes, task_notes)
             .await?;
 
         let limit_config = &self.config.general.tcp_sock_speed_limit;

--- a/g3proxy/src/escape/proxy_socks5s/tcp_connect/mod.rs
+++ b/g3proxy/src/escape/proxy_socks5s/tcp_connect/mod.rs
@@ -301,9 +301,10 @@ impl ProxySocks5sEscaper {
         tcp_notes: &mut TcpConnectTaskNotes,
         task_notes: &ServerTaskNotes,
     ) -> Result<(UpstreamAddr, TcpStream), TcpConnectError> {
-        let peer_proxy = self
-            .get_next_proxy(task_notes, task_conf.upstream.host())
-            .clone();
+        let peer_proxy = task_notes
+            .override_next_proxy()
+            .cloned()
+            .unwrap_or_else(|| self.get_next_proxy(task_notes, task_conf.upstream.host()).clone());
 
         let stream = match peer_proxy.host() {
             Host::Ip(ip) => {

--- a/g3proxy/src/lib.rs
+++ b/g3proxy/src/lib.rs
@@ -13,6 +13,7 @@ pub mod resolve;
 pub mod serve;
 pub mod signal;
 pub mod stat;
+pub mod sticky;
 
 mod build;
 mod inspect;

--- a/g3proxy/src/log/task/http_forward.rs
+++ b/g3proxy/src/log/task/http_forward.rs
@@ -4,6 +4,8 @@
  */
 
 use slog::{Logger, slog_info};
+use std::hash::{Hash, Hasher};
+use fnv::FnvHasher;
 
 use g3_slog_types::{
     LtDateTime, LtDuration, LtHttpMethod, LtHttpUri, LtIpAddr, LtUpstreamAddr, LtUuid,
@@ -36,6 +38,25 @@ impl TaskLogForHttpForward<'_> {
             return;
         }
 
+        let mut sticky_key_hash: Option<String> = None;
+        let mut sticky_requested = false;
+        let mut sticky_effective = false;
+        let mut sticky_rotate = false;
+        let mut sticky_ttl = None;
+        let mut sticky_session_id: Option<&str> = None;
+        if let Some(s) = self.task_notes.sticky() {
+            sticky_requested = true;
+            sticky_effective = s.enabled();
+            sticky_rotate = s.rotate;
+            sticky_ttl = Some(LtDuration(s.effective_ttl()));
+            sticky_session_id = s.session_id.as_deref();
+            // hash the sticky key to avoid logging raw identifiers
+            let k = crate::sticky::build_sticky_key(s, self.upstream);
+            let mut hasher = FnvHasher::with_key(0xcbf29ce484222325);
+            k.hash(&mut hasher);
+            sticky_key_hash = Some(format!("{:016x}", hasher.finish()));
+        }
+
         slog_info!(self.logger, "";
             "task_type" => "HttpForward",
             "task_id" => LtUuid(&self.task_notes.id),
@@ -51,6 +72,12 @@ impl TaskLogForHttpForward<'_> {
             "uri" => LtHttpUri::new(&self.http_notes.uri, self.http_notes.uri_log_max_chars),
             "user_agent" => self.http_user_agent,
             "wait_time" => LtDuration(self.task_notes.wait_time),
+            "sticky_requested" => sticky_requested,
+            "sticky_effective" => sticky_effective,
+            "sticky_rotate" => sticky_rotate,
+            "sticky_ttl" => sticky_ttl,
+            "sticky_session_id" => sticky_session_id,
+            "sticky_key_hash" => sticky_key_hash,
         )
     }
 
@@ -59,6 +86,24 @@ impl TaskLogForHttpForward<'_> {
             && user_ctx.skip_log()
         {
             return;
+        }
+
+        let mut sticky_key_hash: Option<String> = None;
+        let mut sticky_requested = false;
+        let mut sticky_effective = false;
+        let mut sticky_rotate = false;
+        let mut sticky_ttl = None;
+        let mut sticky_session_id: Option<&str> = None;
+        if let Some(s) = self.task_notes.sticky() {
+            sticky_requested = true;
+            sticky_effective = s.enabled();
+            sticky_rotate = s.rotate;
+            sticky_ttl = Some(LtDuration(s.effective_ttl()));
+            sticky_session_id = s.session_id.as_deref();
+            let k = crate::sticky::build_sticky_key(s, self.upstream);
+            let mut hasher = FnvHasher::with_key(0xcbf29ce484222325);
+            k.hash(&mut hasher);
+            sticky_key_hash = Some(format!("{:016x}", hasher.finish()));
         }
 
         slog_info!(self.logger, "";
@@ -85,6 +130,14 @@ impl TaskLogForHttpForward<'_> {
             "user_agent" => self.http_user_agent,
             "wait_time" => LtDuration(self.task_notes.wait_time),
             "ready_time" => LtDuration(self.task_notes.ready_time),
+            "sticky_requested" => sticky_requested,
+            "sticky_effective" => sticky_effective,
+            "sticky_rotate" => sticky_rotate,
+            "sticky_ttl" => sticky_ttl,
+            "sticky_session_id" => sticky_session_id,
+            "sticky_key_hash" => sticky_key_hash,
+            "sticky_enabled" => self.tcp_notes.sticky_enabled,
+            "sticky_expires_at" => self.tcp_notes.sticky_expires_at.as_ref().map(LtDateTime),
         )
     }
 
@@ -93,6 +146,24 @@ impl TaskLogForHttpForward<'_> {
             && user_ctx.skip_log()
         {
             return;
+        }
+
+        let mut sticky_key_hash: Option<String> = None;
+        let mut sticky_requested = false;
+        let mut sticky_effective = false;
+        let mut sticky_rotate = false;
+        let mut sticky_ttl = None;
+        let mut sticky_session_id: Option<&str> = None;
+        if let Some(s) = self.task_notes.sticky() {
+            sticky_requested = true;
+            sticky_effective = s.enabled();
+            sticky_rotate = s.rotate;
+            sticky_ttl = Some(LtDuration(s.effective_ttl()));
+            sticky_session_id = s.session_id.as_deref();
+            let k = crate::sticky::build_sticky_key(s, self.upstream);
+            let mut hasher = FnvHasher::with_key(0xcbf29ce484222325);
+            k.hash(&mut hasher);
+            sticky_key_hash = Some(format!("{:016x}", hasher.finish()));
         }
 
         slog_info!(self.logger, "";
@@ -130,6 +201,14 @@ impl TaskLogForHttpForward<'_> {
             "c_wr_bytes" => self.client_wr_bytes,
             "r_rd_bytes" => self.remote_rd_bytes,
             "r_wr_bytes" => self.remote_wr_bytes,
+            "sticky_requested" => sticky_requested,
+            "sticky_effective" => sticky_effective,
+            "sticky_rotate" => sticky_rotate,
+            "sticky_ttl" => sticky_ttl,
+            "sticky_session_id" => sticky_session_id,
+            "sticky_key_hash" => sticky_key_hash,
+            "sticky_enabled" => self.tcp_notes.sticky_enabled,
+            "sticky_expires_at" => self.tcp_notes.sticky_expires_at.as_ref().map(LtDateTime),
         )
     }
 
@@ -138,6 +217,24 @@ impl TaskLogForHttpForward<'_> {
             && user_ctx.skip_log()
         {
             return;
+        }
+
+        let mut sticky_key_hash: Option<String> = None;
+        let mut sticky_requested = false;
+        let mut sticky_effective = false;
+        let mut sticky_rotate = false;
+        let mut sticky_ttl = None;
+        let mut sticky_session_id: Option<&str> = None;
+        if let Some(s) = self.task_notes.sticky() {
+            sticky_requested = true;
+            sticky_effective = s.enabled();
+            sticky_rotate = s.rotate;
+            sticky_ttl = Some(LtDuration(s.effective_ttl()));
+            sticky_session_id = s.session_id.as_deref();
+            let k = crate::sticky::build_sticky_key(s, self.upstream);
+            let mut hasher = FnvHasher::with_key(0xcbf29ce484222325);
+            k.hash(&mut hasher);
+            sticky_key_hash = Some(format!("{:016x}", hasher.finish()));
         }
 
         slog_info!(self.logger, "{}", e;
@@ -176,6 +273,14 @@ impl TaskLogForHttpForward<'_> {
             "c_wr_bytes" => self.client_wr_bytes,
             "r_rd_bytes" => self.remote_rd_bytes,
             "r_wr_bytes" => self.remote_wr_bytes,
+            "sticky_requested" => sticky_requested,
+            "sticky_effective" => sticky_effective,
+            "sticky_rotate" => sticky_rotate,
+            "sticky_ttl" => sticky_ttl,
+            "sticky_session_id" => sticky_session_id,
+            "sticky_key_hash" => sticky_key_hash,
+            "sticky_enabled" => self.tcp_notes.sticky_enabled,
+            "sticky_expires_at" => self.tcp_notes.sticky_expires_at.as_ref().map(LtDateTime),
         )
     }
 }

--- a/g3proxy/src/main.rs
+++ b/g3proxy/src/main.rs
@@ -4,7 +4,7 @@
  */
 
 use anyhow::Context;
-use log::{debug, error, info};
+use log::{debug, error, info, warn};
 
 use g3_daemon::control::{QuitAction, UpgradeAction};
 
@@ -52,6 +52,20 @@ fn main() -> anyhow::Result<()> {
         }
     };
     debug!("loaded config from {}", config_file.display());
+
+    // Log sticky refresh throttling interval (env-tunable)
+    {
+        let d = g3proxy::sticky::refresh_min_interval();
+        info!(
+            "sticky: refresh_min_interval = {}",
+            humantime::format_duration(d)
+        );
+        if d.is_zero() {
+            warn!(
+                "sticky: refresh_min_interval is 0; throttling disabled and may spawn excessive refresh tasks"
+            );
+        }
+    }
 
     if proc_args.daemon_config.test_config {
         info!("the format of the config file is ok");

--- a/g3proxy/src/module/http_forward/response/client.rs
+++ b/g3proxy/src/module/http_forward/response/client.rs
@@ -520,10 +520,9 @@ impl HttpProxyClientResponse {
                 "<html>\n\
                  <head><title>{code} {reason}</title></head>\n\
                  <body>\n\
-                 <div style=\"text-align: center;\"><h1>{}</h1></div>\n\
+                 <div style=\"text-align: center;\"><h1>{msg}</h1></div>\n\
                  </body>\n\
                  </html>\n",
-                msg
             )
         } else {
             format!(

--- a/g3proxy/src/module/http_header/mod.rs
+++ b/g3proxy/src/module/http_header/mod.rs
@@ -8,6 +8,7 @@ mod standard;
 
 pub(crate) use custom::{
     dynamic_egress_info, outgoing_ip, remote_connection_info, set_dynamic_egress_info,
-    set_outgoing_ip, set_remote_connection_info, set_upstream_addr, set_upstream_id, upstream_addr,
+    set_outgoing_ip, set_remote_connection_info, set_sticky_expires_at, set_sticky_session,
+    set_upstream_addr, set_upstream_id, sticky_expires_at_line, sticky_session_line, upstream_addr,
 };
 pub(crate) use standard::proxy_authorization_basic_pass;

--- a/g3proxy/src/module/tcp_connect/task.rs
+++ b/g3proxy/src/module/tcp_connect/task.rs
@@ -62,6 +62,9 @@ pub(crate) struct TcpConnectTaskNotes {
     pub(crate) egress: Option<EgressInfo>,
     pub(crate) chained: TcpConnectChainedNotes,
     pub(crate) duration: Duration,
+    // sticky session info (when enabled)
+    pub(crate) sticky_enabled: bool,
+    pub(crate) sticky_expires_at: Option<DateTime<Utc>>,
 }
 
 impl TcpConnectTaskNotes {
@@ -75,5 +78,7 @@ impl TcpConnectTaskNotes {
         self.egress = None;
         self.chained.reset();
         self.duration = Duration::ZERO;
+        self.sticky_enabled = false;
+        self.sticky_expires_at = None;
     }
 }

--- a/g3proxy/src/serve/http_proxy/task/common.rs
+++ b/g3proxy/src/serve/http_proxy/task/common.rs
@@ -110,6 +110,12 @@ impl CommonTaskContext {
                 rsp.set_outgoing_ip(addr.ip());
             }
         }
+
+        // DX sticky headers
+        rsp.add_extra_header(http_header::sticky_session_line(tcp_notes.sticky_enabled));
+        if let Some(exp) = &tcp_notes.sticky_expires_at {
+            rsp.add_extra_header(http_header::sticky_expires_at_line(exp));
+        }
     }
 
     pub(crate) fn set_custom_header_for_adaptation_error_reply(

--- a/g3proxy/src/serve/http_proxy/task/connect/task.rs
+++ b/g3proxy/src/serve/http_proxy/task/connect/task.rs
@@ -122,6 +122,21 @@ impl HttpProxyConnectTask {
     where
         W: AsyncWrite + Unpin,
     {
+        // If the next-hop was derived from username params and DNS failed,
+        // treat it as a bad request (400) instead of origin DNS error.
+        if matches!(e, TcpConnectError::ResolveFailed(_))
+            && self.task_notes.override_next_proxy().is_some()
+        {
+            let mut rsp = HttpProxyClientResponse::bad_request(self.http_version);
+            rsp.set_error_message("Proxy targeting didn't find a match");
+            self.ctx
+                .set_custom_header_for_local_reply(&self.tcp_notes, &mut rsp);
+            let should_close = rsp.should_close();
+            self.back_to_http = !should_close;
+            let _ = rsp.reply_err_to_request(clt_w).await;
+            return;
+        }
+
         let mut rsp =
             HttpProxyClientResponse::from_tcp_connect_error(e, http::Version::HTTP_11, false);
         self.ctx

--- a/g3proxy/src/serve/http_proxy/task/connect/task.rs
+++ b/g3proxy/src/serve/http_proxy/task/connect/task.rs
@@ -124,8 +124,8 @@ impl HttpProxyConnectTask {
     {
         // If the next-hop was derived from username params and DNS failed,
         // treat it as a bad request (400) instead of origin DNS error.
-        if matches!(e, TcpConnectError::ResolveFailed(_))
-            && self.task_notes.override_next_proxy().is_some()
+        if self.task_notes.override_next_proxy().is_some()
+            && matches!(e, TcpConnectError::ResolveFailed(_))
         {
             let mut rsp = HttpProxyClientResponse::bad_request(self.http_version);
             rsp.set_error_message("Proxy targeting didn't find a match");

--- a/g3proxy/src/serve/http_proxy/task/forward/task.rs
+++ b/g3proxy/src/serve/http_proxy/task/forward/task.rs
@@ -1421,7 +1421,7 @@ impl<'a> HttpProxyForwardTask<'a> {
                         return Err(ServerTaskError::CanceledAsServerQuit)
                     }
                 }
-            };
+            }
         }
         drop(idle_interval);
 

--- a/g3proxy/src/serve/http_proxy/task/forward/task.rs
+++ b/g3proxy/src/serve/http_proxy/task/forward/task.rs
@@ -162,8 +162,9 @@ impl<'a> HttpProxyForwardTask<'a> {
     {
         // If the next-hop was derived from username params and DNS failed,
         // treat it as a bad request (400) instead of origin DNS error.
-        if matches!(e, TcpConnectError::ResolveFailed(_))
-            && self.task_notes.override_next_proxy().is_some()
+        // Check override_next_proxy() first (per review).
+        if self.task_notes.override_next_proxy().is_some()
+            && matches!(e, TcpConnectError::ResolveFailed(_))
         {
             let mut rsp = HttpProxyClientResponse::bad_request(self.req.version);
             rsp.set_error_message("Proxy targeting didn't find a match");

--- a/g3proxy/src/serve/http_proxy/task/pipeline/writer.rs
+++ b/g3proxy/src/serve/http_proxy/task/pipeline/writer.rs
@@ -138,14 +138,14 @@ where
                 HttpAuth::Basic(v) => {
                     // optionally strip "+params" suffix before auth
                     let mut base_username: Option<Username> = None;
-                    if let Some(cfg) = &self.ctx.server_config.username_params_to_escaper_addr {
-                        if cfg.strip_suffix_for_auth {
-                            let base = crate::serve::username_params::ParsedUsernameParams::auth_base(
-                                v.username.as_original(),
-                            );
-                            if base != v.username.as_original() {
-                                base_username = Username::from_original(base).ok();
-                            }
+                    if let Some(cfg) = &self.ctx.server_config.username_params_to_escaper_addr
+                        && cfg.strip_suffix_for_auth
+                    {
+                        let base = crate::serve::username_params::ParsedUsernameParams::auth_base(
+                            v.username.as_original(),
+                        );
+                        if base != v.username.as_original() {
+                            base_username = Username::from_original(base).ok();
                         }
                     }
                     let username_ref = base_username.as_ref().unwrap_or(&v.username);
@@ -275,35 +275,35 @@ where
         );
 
         // Optional: compute username-param-derived escaper address and store override
-        if let Some(cfg) = &self.ctx.server_config.username_params_to_escaper_addr {
-            if let HttpAuth::Basic(v) = &req.inner.auth_info {
-                let u = v.username.as_original();
-                if crate::serve::username_params::username_has_known_key(cfg, u) {
-                    match crate::serve::username_params::compute_upstream_from_username(
-                        cfg,
-                        u,
-                        crate::serve::username_params::InboundKind::Http,
-                    ) {
-                        Ok(addr) => {
-                            task_notes.set_override_next_proxy(addr);
-                            debug!(
-                                "[{}] http username params -> next proxy {}",
-                                self.ctx.server_config.name(),
-                                task_notes
-                                    .override_next_proxy()
-                                    .map(|a| a.to_string())
-                                    .unwrap_or_else(|| "<none>".into())
-                            );
+        if let Some(cfg) = &self.ctx.server_config.username_params_to_escaper_addr
+            && let HttpAuth::Basic(v) = &req.inner.auth_info
+        {
+            let u = v.username.as_original();
+            if crate::serve::username_params::username_has_known_key(cfg, u) {
+                match crate::serve::username_params::compute_upstream_from_username(
+                    cfg,
+                    u,
+                    crate::serve::username_params::InboundKind::Http,
+                ) {
+                    Ok(addr) => {
+                        task_notes.set_override_next_proxy(addr);
+                        debug!(
+                            "[{}] http username params -> next proxy {}",
+                            self.ctx.server_config.name(),
+                            task_notes
+                                .override_next_proxy()
+                                .map(|a| a.to_string())
+                                .unwrap_or_else(|| "<none>".into())
+                        );
+                    }
+                    Err(_e) => {
+                        // Bad request: unsupported param combo or invalid params
+                        if let Some(stream_w) = &mut self.stream_writer {
+                            let rsp = HttpProxyClientResponse::bad_request(req.inner.version);
+                            let _ = rsp.reply_err_to_request(stream_w).await;
                         }
-                        Err(_e) => {
-                            // Bad request: unsupported param combo or invalid params
-                            if let Some(stream_w) = &mut self.stream_writer {
-                                let rsp = HttpProxyClientResponse::bad_request(req.inner.version);
-                                let _ = rsp.reply_err_to_request(stream_w).await;
-                            }
-                            self.notify_reader_to_close();
-                            return LoopAction::Break;
-                        }
+                        self.notify_reader_to_close();
+                        return LoopAction::Break;
                     }
                 }
             }

--- a/g3proxy/src/serve/mod.rs
+++ b/g3proxy/src/serve/mod.rs
@@ -52,6 +52,7 @@ mod tls_stream;
 
 mod error;
 mod task;
+mod username_params;
 
 pub(crate) use error::{ServerTaskError, ServerTaskForbiddenError, ServerTaskResult};
 pub(crate) use task::{ServerTaskNotes, ServerTaskStage};

--- a/g3proxy/src/serve/sni_proxy/task/accept/tls.rs
+++ b/g3proxy/src/serve/sni_proxy/task/accept/tls.rs
@@ -96,7 +96,7 @@ mod tests {
     use super::*;
     use std::sync::Arc;
 
-    #[tokio::test]
+    #[tokio::test(flavor = "current_thread")]
     async fn single_read() {
         let data: &[u8] = &[
             0x16, //
@@ -138,7 +138,7 @@ mod tests {
         );
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "current_thread")]
     async fn multi_read() {
         let data: &[u8] = &[
             0x16, //
@@ -187,7 +187,7 @@ mod tests {
         );
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "current_thread")]
     async fn multi_record() {
         const RECORD_1_BYTES: &[u8] = &[
             0x16, 0x03, 0x01, 0x00, 0x64, 0x01, 0x00, 0x01, 0x8a, 0x03, 0x03, 0x02, 0x86, 0x70,

--- a/g3proxy/src/serve/socks_proxy/task/negotiation/task.rs
+++ b/g3proxy/src/serve/socks_proxy/task/negotiation/task.rs
@@ -239,14 +239,14 @@ impl SocksProxyNegotiationTask {
                     let username_original = username.as_original().to_string();
                     // optionally strip suffix for auth
                     let mut base_username: Option<Username> = None;
-                    if let Some(cfg) = &self.ctx.server_config.username_params_to_escaper_addr {
-                        if cfg.strip_suffix_for_auth {
-                            let base = crate::serve::username_params::ParsedUsernameParams::auth_base(
-                                &username_original,
-                            );
-                            if base != username_original {
-                                base_username = Username::from_original(base).ok();
-                            }
+                    if let Some(cfg) = &self.ctx.server_config.username_params_to_escaper_addr
+                        && cfg.strip_suffix_for_auth
+                    {
+                        let base = crate::serve::username_params::ParsedUsernameParams::auth_base(
+                            &username_original,
+                        );
+                        if base != username_original {
+                            base_username = Username::from_original(base).ok();
                         }
                     }
                     let username_ref = base_username.as_ref().unwrap_or(&username);
@@ -296,22 +296,22 @@ impl SocksProxyNegotiationTask {
 
         // compute mapping after auth success but before task creation; deny on error
         let mut override_next: Option<UpstreamAddr> = None;
-        if let Some(cfg) = &self.ctx.server_config.username_params_to_escaper_addr {
-            if let Some(name) = &username_for_mapping {
-                // Only attempt mapping when at least one known key appears
-                if crate::serve::username_params::username_has_known_key(cfg, name) {
-                    match crate::serve::username_params::compute_upstream_from_username(
-                        cfg,
-                        name,
-                        crate::serve::username_params::InboundKind::Socks5,
-                    ) {
-                        Ok(a) => override_next = Some(a),
-                        Err(_e) => {
-                            let _ = v5::Socks5Reply::ForbiddenByRule.send(&mut clt_w).await;
-                            return Err(ServerTaskError::ForbiddenByRule(
-                                ServerTaskForbiddenError::DestDenied,
-                            ));
-                        }
+        if let Some(cfg) = &self.ctx.server_config.username_params_to_escaper_addr
+            && let Some(name) = &username_for_mapping
+        {
+            // Only attempt mapping when at least one known key appears
+            if crate::serve::username_params::username_has_known_key(cfg, name) {
+                match crate::serve::username_params::compute_upstream_from_username(
+                    cfg,
+                    name,
+                    crate::serve::username_params::InboundKind::Socks5,
+                ) {
+                    Ok(a) => override_next = Some(a),
+                    Err(_e) => {
+                        let _ = v5::Socks5Reply::ForbiddenByRule.send(&mut clt_w).await;
+                        return Err(ServerTaskError::ForbiddenByRule(
+                            ServerTaskForbiddenError::DestDenied,
+                        ));
                     }
                 }
             }

--- a/g3proxy/src/serve/socks_proxy/task/negotiation/task.rs
+++ b/g3proxy/src/serve/socks_proxy/task/negotiation/task.rs
@@ -214,6 +214,7 @@ impl SocksProxyNegotiationTask {
             .map_err(ServerTaskError::ClientTcpWriteFailed)?;
 
         let mut username_for_mapping: Option<String> = None;
+        let mut sticky_decision: Option<crate::sticky::StickyDecision> = None;
         let user_ctx = match auth_method {
             SocksAuthMethod::None => {
                 if let Some(user_group) = &self.user_group {
@@ -237,6 +238,11 @@ impl SocksProxyNegotiationTask {
                     let (username, password) = v5::auth::recv_user_from_client(&mut clt_r).await?;
                     // preserve original username for mapping
                     let username_original = username.as_original().to_string();
+                    // parse sticky decision from the original username
+                    let (_base_for_sticky, decision) =
+                        crate::sticky::parse_username_and_decision(&username_original);
+                    sticky_decision = Some(decision);
+
                     // optionally strip suffix for auth
                     let mut base_username: Option<Username> = None;
                     if let Some(cfg) = &self.ctx.server_config.username_params_to_escaper_addr
@@ -316,7 +322,6 @@ impl SocksProxyNegotiationTask {
                 }
             }
         }
-
         let mut task_notes = ServerTaskNotes::new(
             self.ctx.cc_info.clone(),
             user_ctx,
@@ -333,6 +338,7 @@ impl SocksProxyNegotiationTask {
                     .unwrap_or_else(|| "<none>".into())
             );
         }
+        if let Some(dec) = sticky_decision { task_notes.set_sticky(dec); }
         match req.command {
             SocksCommand::TcpConnect => {
                 let task = SocksProxyTcpConnectTask::new(

--- a/g3proxy/src/serve/socks_proxy/task/negotiation/task.rs
+++ b/g3proxy/src/serve/socks_proxy/task/negotiation/task.rs
@@ -11,6 +11,7 @@ use tokio::time::Instant;
 
 use g3_io_ext::{AsyncStream, LimitedReader, LimitedWriter};
 use g3_socks::{SocksAuthMethod, SocksCommand, SocksVersion, v4a, v5};
+use g3_types::auth::Username;
 
 use super::tcp_connect::SocksProxyTcpConnectTask;
 use super::udp_associate::SocksProxyUdpAssociateTask;
@@ -211,6 +212,7 @@ impl SocksProxyNegotiationTask {
             .await
             .map_err(ServerTaskError::ClientTcpWriteFailed)?;
 
+        let mut username_for_mapping: Option<String> = None;
         let user_ctx = match auth_method {
             SocksAuthMethod::None => {
                 if let Some(user_group) = &self.user_group {
@@ -232,8 +234,23 @@ impl SocksProxyNegotiationTask {
             SocksAuthMethod::User => {
                 if let Some(user_group) = &self.user_group {
                     let (username, password) = v5::auth::recv_user_from_client(&mut clt_r).await?;
+                    // preserve original username for mapping
+                    let username_original = username.as_original().to_string();
+                    // optionally strip suffix for auth
+                    let mut base_username: Option<Username> = None;
+                    if let Some(cfg) = &self.ctx.server_config.username_params_to_escaper_addr {
+                        if cfg.strip_suffix_for_auth {
+                            let base = crate::serve::username_params::ParsedUsernameParams::auth_base(
+                                &username_original,
+                            );
+                            if base != username_original {
+                                base_username = Username::from_original(base).ok();
+                            }
+                        }
+                    }
+                    let username_ref = base_username.as_ref().unwrap_or(&username);
                     match user_group.check_user_with_password(
-                        &username,
+                        username_ref,
                         &password,
                         self.ctx.server_config.name(),
                         self.ctx.server_stats.share_extra_tags(),
@@ -248,6 +265,8 @@ impl SocksProxyNegotiationTask {
                             v5::auth::send_user_auth_success(&mut clt_w)
                                 .await
                                 .map_err(ServerTaskError::ClientTcpWriteFailed)?;
+                            // store original username for later mapping
+                            username_for_mapping = Some(username_original);
                             Some(user_ctx)
                         }
                         Err(e) => {
@@ -274,11 +293,42 @@ impl SocksProxyNegotiationTask {
 
         let req = v5::Socks5Request::recv(&mut clt_r).await?;
 
-        let task_notes = ServerTaskNotes::new(
+        // compute mapping after auth success but before task creation; deny on error
+        let mut override_next: Option<g3_types::net::UpstreamAddr> = None;
+        if let Some(cfg) = &self.ctx.server_config.username_params_to_escaper_addr {
+            if let Some(name) = &username_for_mapping {
+                match crate::serve::username_params::compute_upstream_from_username(
+                    cfg,
+                    name,
+                    crate::serve::username_params::InboundKind::Socks5,
+                ) {
+                    Ok(a) => override_next = Some(a),
+                    Err(_e) => {
+                        let _ = v5::Socks5Reply::ForbiddenByRule.send(&mut clt_w).await;
+                        return Err(ServerTaskError::ForbiddenByRule(
+                            ServerTaskForbiddenError::DestDenied,
+                        ));
+                    }
+                }
+            }
+        }
+
+        let mut task_notes = ServerTaskNotes::new(
             self.ctx.cc_info.clone(),
             user_ctx,
             self.time_accepted.elapsed(),
         );
+        if let Some(a) = override_next.take() {
+            task_notes.set_override_next_proxy(a);
+            debug!(
+                "[{}] socks username params -> next proxy {}",
+                self.ctx.server_config.name(),
+                task_notes
+                    .override_next_proxy()
+                    .map(|a| a.to_string())
+                    .unwrap_or_else(|| "<none>".into())
+            );
+        }
         match req.command {
             SocksCommand::TcpConnect => {
                 let task = SocksProxyTcpConnectTask::new(

--- a/g3proxy/src/serve/socks_proxy/task/tcp_connect/task.rs
+++ b/g3proxy/src/serve/socks_proxy/task/tcp_connect/task.rs
@@ -489,9 +489,8 @@ impl StreamTransitTask for SocksProxyTcpConnectTask {
     }
 
     fn log_client_shutdown(&self) {
-        if let Some(log_ctx) = self.get_log_context() {
-            log_ctx.log_client_shutdown();
-        }
+        // Intentionally no-op to avoid duplicate INFO lines.
+        // We emit a single final Finished log for this task, matching HTTP behavior.
     }
 
     fn log_upstream_shutdown(&self) {

--- a/g3proxy/src/serve/socks_proxy/task/tcp_connect/task.rs
+++ b/g3proxy/src/serve/socks_proxy/task/tcp_connect/task.rs
@@ -489,8 +489,9 @@ impl StreamTransitTask for SocksProxyTcpConnectTask {
     }
 
     fn log_client_shutdown(&self) {
-        // Intentionally no-op to avoid duplicate INFO lines.
-        // We emit a single final Finished log for this task, matching HTTP behavior.
+        if let Some(log_ctx) = self.get_log_context() {
+            log_ctx.log_client_shutdown();
+        }
     }
 
     fn log_upstream_shutdown(&self) {

--- a/g3proxy/src/serve/task.rs
+++ b/g3proxy/src/serve/task.rs
@@ -166,3 +166,29 @@ impl ServerTaskNotes {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use g3_daemon::server::ClientConnectionInfo;
+    use g3_types::net::{Host, UpstreamAddr};
+
+    #[test]
+    fn override_next_proxy_helpers() {
+        let cc = ClientConnectionInfo::new(
+            "127.0.0.1:10000".parse().unwrap(),
+            "127.0.0.1:20000".parse().unwrap(),
+        );
+        let mut notes = ServerTaskNotes::new(cc, None, Duration::from_secs(0));
+        assert!(notes.override_next_proxy().is_none());
+
+        let addr = UpstreamAddr::from_host_str_and_port("127.0.0.1", 8080).unwrap();
+        notes.set_override_next_proxy(addr.clone());
+        let got = notes.override_next_proxy().unwrap();
+        assert_eq!(got.port(), 8080);
+        match got.host() {
+            Host::Ip(ip) => assert_eq!(ip.to_string(), "127.0.0.1"),
+            _ => panic!("expected ip host"),
+        }
+    }
+}

--- a/g3proxy/src/serve/task.rs
+++ b/g3proxy/src/serve/task.rs
@@ -17,6 +17,7 @@ use g3_types::net::UpstreamAddr;
 
 use crate::auth::UserContext;
 use crate::escape::EgressPathSelection;
+use crate::sticky::StickyDecision;
 
 #[derive(Clone, Copy)]
 pub(crate) enum ServerTaskStage {
@@ -62,6 +63,7 @@ pub(crate) struct ServerTaskNotes {
     override_next_proxy: Option<UpstreamAddr>,
     /// the following fields should not be cloned
     pub(crate) user_req_alive_permit: Option<GaugeSemaphorePermit>,
+    sticky: Option<StickyDecision>,
 }
 
 impl ServerTaskNotes {
@@ -93,6 +95,7 @@ impl ServerTaskNotes {
             egress_path_selection,
             override_next_proxy: None,
             user_req_alive_permit: None,
+            sticky: None,
         }
     }
 
@@ -146,6 +149,16 @@ impl ServerTaskNotes {
     #[inline]
     pub(crate) fn override_next_proxy(&self) -> Option<&UpstreamAddr> {
         self.override_next_proxy.as_ref()
+    }
+
+    #[inline]
+    pub(crate) fn sticky(&self) -> Option<&StickyDecision> {
+        self.sticky.as_ref()
+    }
+
+    #[inline]
+    pub(crate) fn set_sticky(&mut self, decision: StickyDecision) {
+        self.sticky = Some(decision);
     }
 
     #[inline]

--- a/g3proxy/src/serve/username_params.rs
+++ b/g3proxy/src/serve/username_params.rs
@@ -92,18 +92,19 @@ pub(crate) fn compute_upstream_from_username(
         // if a later non-floating key appears, all earlier non-floating must be present
         let mut saw_missing_required = false;
         for key in &cfg.keys_for_host {
+            let key_s = key.as_str();
             let is_floating = cfg.floating_keys.contains(key);
-            match parsed.params.get(key) {
+            match parsed.params.get(key_s) {
                 Some(_v) => {
                     if saw_missing_required && !is_floating {
                         debug!(
                             "username-params: hierarchy violation at key '{}' (floating={})",
-                            key.as_str(),
+                            key_s,
                             is_floating
                         );
                         return Err(anyhow!(
                             "key {} requires its ancestor keys to be present",
-                            key.as_str()
+                            key_s
                         ));
                     }
                 }

--- a/g3proxy/src/serve/username_params.rs
+++ b/g3proxy/src/serve/username_params.rs
@@ -219,7 +219,6 @@ mod tests {
         c.require_hierarchy = true;
         c.reject_unknown_keys = true;
         c.floating_keys = Vec::new();
-        c.global_label = "global".to_string();
         c.http_port = 10000;
         c.socks5_port = 10001;
         c

--- a/g3proxy/src/serve/username_params.rs
+++ b/g3proxy/src/serve/username_params.rs
@@ -1,0 +1,340 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright 2025 ByteDance and/or its affiliates.
+ */
+
+use std::collections::HashMap;
+
+use anyhow::anyhow;
+use log::debug;
+
+use g3_types::net::UpstreamAddr;
+
+use crate::config::server::username_params_to_escaper::UsernameParamsToEscaperConfig;
+
+#[derive(Debug, Clone)]
+pub(crate) struct ParsedUsernameParams {
+    pub(crate) base: String,
+    pub(crate) params: HashMap<String, String>,
+}
+
+impl ParsedUsernameParams {
+    pub(crate) fn parse(original: &str) -> anyhow::Result<Self> {
+        // expected format: base[+key=value]*, keys/values are non-empty, no escaping
+        let mut it = original.split('+');
+        let base = it
+            .next()
+            .ok_or_else(|| anyhow!("empty username"))?
+            .to_string();
+        let mut params = HashMap::new();
+        for t in it {
+            let mut kv = t.splitn(2, '=');
+            let k = kv
+                .next()
+                .ok_or_else(|| anyhow!("invalid token: missing key"))?;
+            let v = kv
+                .next()
+                .ok_or_else(|| anyhow!("invalid token: missing value for key {k}"))?;
+            if k.is_empty() || v.is_empty() {
+                return Err(anyhow!("empty key or value in username params"));
+            }
+            if params.contains_key(k) {
+                return Err(anyhow!("duplicate key {k}"));
+            }
+            params.insert(k.to_string(), v.to_string());
+        }
+        Ok(ParsedUsernameParams { base, params })
+    }
+
+    pub(crate) fn auth_base(original: &str) -> &str {
+        // return substring before first '+'
+        if let Some((base, _)) = original.split_once('+') {
+            base
+        } else {
+            original
+        }
+    }
+}
+
+#[derive(Copy, Clone, Debug)]
+pub(crate) enum InboundKind {
+    Http,
+    Socks5,
+}
+
+pub(crate) fn compute_upstream_from_username(
+    cfg: &UsernameParamsToEscaperConfig,
+    username_original: &str,
+    inbound: InboundKind,
+) -> anyhow::Result<UpstreamAddr> {
+    debug!(
+        "username-params: inbound={:?} original='{}'",
+        inbound, username_original
+    );
+    let parsed = ParsedUsernameParams::parse(username_original)?;
+    debug!(
+        "username-params: base='{}' params={:?}",
+        parsed.base, parsed.params
+    );
+
+    // validate keys
+    if cfg.reject_unknown_keys {
+        for k in parsed.params.keys() {
+            if !cfg.keys_for_host.iter().any(|x| x == k) {
+                debug!("username-params: reject unknown key '{}'", k);
+                return Err(anyhow!("unknown key {k}"));
+            }
+        }
+    }
+
+    if cfg.require_hierarchy {
+        // if a later non-floating key appears, all earlier non-floating must be present
+        let mut saw_missing_required = false;
+        for key in &cfg.keys_for_host {
+            let is_floating = cfg.floating_keys.iter().any(|k| k == key);
+            match parsed.params.get(key) {
+                Some(_v) => {
+                    if saw_missing_required && !is_floating {
+                        debug!(
+                            "username-params: hierarchy violation at key '{}' (floating={})",
+                            key, is_floating
+                        );
+                        return Err(anyhow!(
+                            "key {key} requires its ancestor keys to be present"
+                        ));
+                    }
+                }
+                None => {
+                    if !is_floating {
+                        // mark that following present required keys will violate hierarchy
+                        saw_missing_required = true;
+                    }
+                }
+            }
+        }
+    }
+
+    // build host label sequence in configured order, skipping missing keys
+    let mut parts: Vec<&str> = Vec::new();
+    for k in &cfg.keys_for_host {
+        if let Some(v) = parsed.params.get(k) {
+            parts.push(v);
+        }
+    }
+    debug!(
+        "username-params: keys_for_host={:?} floating_keys={:?} used_parts={:?}",
+        cfg.keys_for_host, cfg.floating_keys, parts
+    );
+
+    let port = match inbound {
+        InboundKind::Http => cfg.http_port,
+        InboundKind::Socks5 => cfg.socks5_port,
+    };
+
+    // Build label or use global
+    let label = if parts.is_empty() {
+        debug!("username-params: no parts, using global_label='{}'", cfg.global_label);
+        cfg.global_label.clone()
+    } else {
+        // join with the configured separator
+        let mut s = String::new();
+        for (i, v) in parts.iter().enumerate() {
+            if i > 0 {
+                s.push_str(&cfg.separator);
+            }
+            s.push_str(v);
+        }
+        debug!("username-params: joined label='{}' separator='{}'", s, cfg.separator);
+        s
+    };
+
+    // Apply optional suffix
+    let full_host_cow = cfg.suffix_for_host(&label);
+    let full_host = full_host_cow.as_ref();
+    if !matches!(full_host_cow, std::borrow::Cow::Borrowed(_)) {
+        debug!(
+            "username-params: apply domain_suffix -> host='{}'",
+            full_host
+        );
+    } else {
+        debug!("username-params: no domain_suffix -> host='{}'", full_host);
+    }
+    debug!("username-params: chosen port={} from inbound={:?}", port, inbound);
+
+    // RFC 6761: names in the .localhost domain resolve to loopback.
+    // Honor this locally to avoid relying on external DNS servers.
+    if full_host.eq_ignore_ascii_case("localhost")
+        || full_host.to_ascii_lowercase().ends_with(".localhost")
+    {
+        debug!(
+            "username-params: mapping '{}' to 127.0.0.1 due to .localhost",
+            full_host
+        );
+        return Ok(UpstreamAddr::from_host_str_and_port("127.0.0.1", port)?);
+    }
+
+    debug!(
+        "username-params: final next-hop host='{}' port={}",
+        full_host, port
+    );
+    Ok(UpstreamAddr::from_host_str_and_port(full_host, port)?)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use g3_types::net::Host;
+
+    fn cfg_with_keys(keys: &[&str]) -> UsernameParamsToEscaperConfig {
+        let mut c = UsernameParamsToEscaperConfig::new(None);
+        c.keys_for_host = keys.iter().map(|s| s.to_string()).collect();
+        c.require_hierarchy = true;
+        c.reject_unknown_keys = true;
+        c.floating_keys = Vec::new();
+        c.global_label = "global".to_string();
+        c.http_port = 10000;
+        c.socks5_port = 10001;
+        c
+    }
+
+    #[test]
+    fn auth_base_works() {
+        assert_eq!(ParsedUsernameParams::auth_base("user"), "user");
+        assert_eq!(ParsedUsernameParams::auth_base("user+label1=foo"), "user");
+        assert_eq!(ParsedUsernameParams::auth_base("u+key=v+z=t"), "u");
+    }
+
+    #[test]
+    fn parse_valid_and_duplicate() {
+        let p = ParsedUsernameParams::parse("user+label1=foo+label2=bar").unwrap();
+        assert_eq!(p.base, "user");
+        assert_eq!(p.params.get("label1").unwrap(), "foo");
+        assert_eq!(p.params.get("label2").unwrap(), "bar");
+
+        // duplicate key should error
+        assert!(ParsedUsernameParams::parse("user+label1=foo+label1=baz").is_err());
+    }
+
+    #[test]
+    fn compute_global_defaults() {
+        let cfg = cfg_with_keys(&["label1", "label2", "label3", "label4"]);
+        let ups = compute_upstream_from_username(&cfg, "user", InboundKind::Http).unwrap();
+        assert_eq!(ups.port(), 10000);
+        match ups.host() {
+            Host::Domain(d) => assert_eq!(d.as_ref(), "global"),
+            _ => panic!("expected domain host"),
+        }
+    }
+
+    #[test]
+    fn compute_join_and_ports() {
+        let cfg = cfg_with_keys(&["label1", "label2", "label3"]);
+        let ups = compute_upstream_from_username(
+            &cfg,
+            "user+label1=foo+label2=bar",
+            InboundKind::Http,
+        )
+        .unwrap();
+        assert_eq!(ups.port(), 10000);
+        match ups.host() {
+            Host::Domain(d) => assert_eq!(d.as_ref(), "foo-bar"),
+            _ => panic!("expected domain host"),
+        }
+
+        let ups2 = compute_upstream_from_username(
+            &cfg,
+            "user+label1=foo+label2=bar",
+            InboundKind::Socks5,
+        )
+        .unwrap();
+        assert_eq!(ups2.port(), 10001);
+    }
+
+    #[test]
+    fn compute_unknown_and_hierarchy() {
+        let mut cfg = cfg_with_keys(&["label1", "label2"]);
+        // unknown keys rejected
+        assert!(compute_upstream_from_username(&cfg, "user+x=y", InboundKind::Http).is_err());
+
+        // allow unknown keys when disabled
+        cfg.reject_unknown_keys = false;
+        let ups = compute_upstream_from_username(&cfg, "user+x=y", InboundKind::Http).unwrap();
+        match ups.host() {
+            Host::Domain(d) => assert_eq!(d.as_ref(), "global"),
+            _ => panic!("expected domain host"),
+        }
+
+        // hierarchy enforced: region without country should error
+        cfg.reject_unknown_keys = true;
+        cfg.require_hierarchy = true;
+        assert!(compute_upstream_from_username(&cfg, "user+label2=b", InboundKind::Http).is_err());
+
+        // disable hierarchy and allow trailing keys
+        cfg.require_hierarchy = false;
+        let ups2 = compute_upstream_from_username(&cfg, "user+label2=b", InboundKind::Http)
+            .unwrap();
+        match ups2.host() {
+            Host::Domain(d) => assert_eq!(d.as_ref(), "b"),
+            _ => panic!("expected domain host"),
+        }
+    }
+
+    #[test]
+    fn compute_with_suffix() {
+        let mut cfg = cfg_with_keys(&["label1"]);
+        cfg.domain_suffix = Some(".svc.local".to_string());
+        let ups =
+            compute_upstream_from_username(&cfg, "user+label1=foo", InboundKind::Http).unwrap();
+        match ups.host() {
+            Host::Domain(d) => assert_eq!(d.as_ref(), "foo.svc.local"),
+            _ => panic!("expected domain host"),
+        }
+    }
+
+    #[test]
+    fn compute_with_floating_optional() {
+        // label order: label1, label2, label3, label4, opt; opt is floating (independent)
+        let mut cfg = cfg_with_keys(&["label1", "label2", "label3", "label4", "opt"]);
+        cfg.floating_keys = vec!["opt".to_string()];
+
+        // opt only
+        let ups = compute_upstream_from_username(&cfg, "user+opt=o123", InboundKind::Http)
+            .unwrap();
+        match ups.host() {
+            Host::Domain(d) => assert_eq!(d.as_ref(), "o123"),
+            _ => panic!("expected domain host"),
+        }
+
+        // label1 + opt
+        let ups = compute_upstream_from_username(
+            &cfg,
+            "user+label1=foo+opt=o123",
+            InboundKind::Http,
+        )
+        .unwrap();
+        match ups.host() {
+            Host::Domain(d) => assert_eq!(d.as_ref(), "foo-o123"),
+            _ => panic!("expected domain host"),
+        }
+
+        // full hierarchy + opt
+        let ups = compute_upstream_from_username(
+            &cfg,
+            "user+label1=foo+label2=bar+label3=baz+label4=qux+opt=o123",
+            InboundKind::Http,
+        )
+        .unwrap();
+        match ups.host() {
+            Host::Domain(d) => assert_eq!(d.as_ref(), "foo-bar-baz-qux-o123"),
+            _ => panic!("expected domain host"),
+        }
+
+        // label2 without label1 (still invalid), even if opt present
+        assert!(compute_upstream_from_username(
+            &cfg,
+            "user+label2=bar+opt=o123",
+            InboundKind::Http,
+        )
+        .is_err());
+    }
+}

--- a/g3proxy/src/serve/username_params.rs
+++ b/g3proxy/src/serve/username_params.rs
@@ -198,14 +198,14 @@ pub(crate) fn compute_upstream_from_username(
             "username-params: mapping '{}' to 127.0.0.1 due to .localhost",
             full_host
         );
-        return Ok(UpstreamAddr::from_host_str_and_port("127.0.0.1", port)?);
+        return UpstreamAddr::from_host_str_and_port("127.0.0.1", port);
     }
 
     debug!(
         "username-params: final next-hop host='{}' port={}",
         full_host, port
     );
-    Ok(UpstreamAddr::from_host_str_and_port(full_host, port)?)
+    UpstreamAddr::from_host_str_and_port(full_host, port)
 }
 
 #[cfg(test)]

--- a/g3proxy/src/serve/username_params.rs
+++ b/g3proxy/src/serve/username_params.rs
@@ -92,19 +92,19 @@ pub(crate) fn compute_upstream_from_username(
         // if a later non-floating key appears, all earlier non-floating must be present
         let mut saw_missing_required = false;
         for key in &cfg.keys_for_host {
-            let key_s = key.as_str();
+            let key_name = key.as_str().to_owned();
             let is_floating = cfg.floating_keys.contains(key);
-            match parsed.params.get(key_s) {
+            match parsed.params.get(key_name.as_str()) {
                 Some(_v) => {
                     if saw_missing_required && !is_floating {
                         debug!(
                             "username-params: hierarchy violation at key '{}' (floating={})",
-                            key_s,
+                            key_name.as_str(),
                             is_floating
                         );
                         return Err(anyhow!(
                             "key {} requires its ancestor keys to be present",
-                            key_s
+                            key_name.as_str()
                         ));
                     }
                 }

--- a/g3proxy/src/sticky/mod.rs
+++ b/g3proxy/src/sticky/mod.rs
@@ -124,11 +124,11 @@ fn default_ttl() -> Duration {
         return d;
     }
     // allow env override
-    if let Ok(s) = std::env::var("G3_STICKY_DEFAULT_TTL") {
-        if let Ok(d) = humantime::parse_duration(&s) {
-            let _ = DEFAULT_TTL.set(d);
-            return d;
-        }
+    if let Ok(s) = std::env::var("G3_STICKY_DEFAULT_TTL")
+        && let Ok(d) = humantime::parse_duration(&s)
+    {
+        let _ = DEFAULT_TTL.set(d);
+        return d;
     }
     let d = Duration::from_secs(60);
     let _ = DEFAULT_TTL.set(d);
@@ -139,11 +139,11 @@ fn max_ttl() -> Duration {
     if let Some(d) = MAX_TTL.get().copied() {
         return d;
     }
-    if let Ok(s) = std::env::var("G3_STICKY_MAX_TTL") {
-        if let Ok(d) = humantime::parse_duration(&s) {
-            let _ = MAX_TTL.set(d);
-            return d;
-        }
+    if let Ok(s) = std::env::var("G3_STICKY_MAX_TTL")
+        && let Ok(d) = humantime::parse_duration(&s)
+    {
+        let _ = MAX_TTL.set(d);
+        return d;
     }
     let d = Duration::from_secs(3600);
     let _ = MAX_TTL.set(d);
@@ -154,11 +154,11 @@ pub fn refresh_min_interval() -> Duration {
     if let Some(d) = REFRESH_MIN_INTERVAL.get().copied() {
         return d;
     }
-    if let Ok(s) = std::env::var("G3_STICKY_REFRESH_MIN_INTERVAL") {
-        if let Ok(d) = humantime::parse_duration(&s) {
-            let _ = REFRESH_MIN_INTERVAL.set(d);
-            return d;
-        }
+    if let Ok(s) = std::env::var("G3_STICKY_REFRESH_MIN_INTERVAL")
+        && let Ok(d) = humantime::parse_duration(&s)
+    {
+        let _ = REFRESH_MIN_INTERVAL.set(d);
+        return d;
     }
     let d = Duration::from_millis(250);
     let _ = REFRESH_MIN_INTERVAL.set(d);
@@ -170,31 +170,27 @@ pub fn set_redis_url(url: Option<&str>) {
         Some(s) if !s.is_empty() => {
             let _ = REDIS_URL.set(Some(s.to_string()));
             // best-effort parse and cache a client config
-            
-            if let Ok(u) = Url::parse(s) {
-                if let Some(host) = u.host_str() {
-                    let port = u.port().unwrap_or(g3_redis_client::REDIS_DEFAULT_PORT);
-                    if let Ok(upstream) = g3_types::net::UpstreamAddr::from_host_str_and_port(host, port) {
-                        let mut builder = g3_redis_client::RedisClientConfigBuilder::new(upstream);
-                        // db
-                        let path = u.path();
-                        let db_str = path.strip_prefix('/').unwrap_or(path);
-                        if !db_str.is_empty() {
-                            if let Ok(db) = db_str.parse::<i64>() { builder.set_db(db); }
-                        }
-                        // user/pass
-                        let username = u.username();
-                        if !username.is_empty() { builder.set_username(username.to_string()); }
-                        if let Some(password) = u.password() { builder.set_password(password.to_string()); }
-                        // query params as yaml kv
-                        for (k, v) in u.query_pairs() {
-                            let yaml_val = yaml_rust::Yaml::String(v.to_string());
-                            let _ = builder.set_by_yaml_kv(&k, &yaml_val, None);
-                        }
-                        if let Ok(client_cfg) = builder.build() {
-                            let _ = REDIS_CLIENT.set(Some(client_cfg));
-                        }
- 
+            if let Ok(u) = Url::parse(s)
+                && let Some(host) = u.host_str()
+            {
+                let port = u.port().unwrap_or(g3_redis_client::REDIS_DEFAULT_PORT);
+                if let Ok(upstream) = g3_types::net::UpstreamAddr::from_host_str_and_port(host, port) {
+                    let mut builder = g3_redis_client::RedisClientConfigBuilder::new(upstream);
+                    // db
+                    let path = u.path();
+                    let db_str = path.strip_prefix('/').unwrap_or(path);
+                    if !db_str.is_empty() && let Ok(db) = db_str.parse::<i64>() { builder.set_db(db); }
+                    // user/pass
+                    let username = u.username();
+                    if !username.is_empty() { builder.set_username(username.to_string()); }
+                    if let Some(password) = u.password() { builder.set_password(password.to_string()); }
+                    // query params as yaml kv
+                    for (k, v) in u.query_pairs() {
+                        let yaml_val = yaml_rust::Yaml::String(v.to_string());
+                        let _ = builder.set_by_yaml_kv(&k, &yaml_val, None);
+                    }
+                    if let Ok(client_cfg) = builder.build() {
+                        let _ = REDIS_CLIENT.set(Some(client_cfg));
                     }
                 }
             }
@@ -282,7 +278,7 @@ pub async fn redis_get_ip(key: &str) -> Option<IpAddr> {
     }
     let client_cfg = match REDIS_CLIENT.get().and_then(|o| o.as_ref()) { Some(c) => c, None => return None };
     let mut conn = match client_cfg.connect().await { Ok(c) => c, Err(_) => return None };
-    let s: Option<String> = match conn.get(key).await { Ok(v) => v, Err(_) => None };
+    let s: Option<String> = (conn.get(key).await).unwrap_or_default();
     s.and_then(|v| v.parse::<IpAddr>().ok())
 }
 
@@ -293,17 +289,17 @@ pub async fn redis_set_ip(key: &str, ip: IpAddr, ttl: Duration) {
         mock_store().lock().unwrap().insert(key.to_string(), (ip, exp));
     }
     
-    if let Some(client_cfg) = REDIS_CLIENT.get().and_then(|o| o.as_ref()) {
-        if let Ok(mut conn) = client_cfg.connect().await {
-            // Use atomic SET with EX
-            let _: redis::RedisResult<()> = redis::cmd("SET")
-                .arg(key)
-                .arg(ip.to_string())
-                .arg("EX")
-                .arg(ttl.as_secs() as i64)
-                .query_async(&mut conn)
-                .await;
-        }
+    if let Some(client_cfg) = REDIS_CLIENT.get().and_then(|o| o.as_ref())
+        && let Ok(mut conn) = client_cfg.connect().await
+    {
+        // Use atomic SET with EX
+        let _: redis::RedisResult<()> = redis::cmd("SET")
+            .arg(key)
+            .arg(ip.to_string())
+            .arg("EX")
+            .arg(ttl.as_secs() as i64)
+            .query_async(&mut conn)
+            .await;
     }
 }
 
@@ -316,10 +312,10 @@ pub async fn redis_refresh_ttl(key: &str, ttl: Duration) {
         }
     }
     
-    if let Some(client_cfg) = REDIS_CLIENT.get().and_then(|o| o.as_ref()) {
-        if let Ok(mut conn) = client_cfg.connect().await {
-            let _ : redis::RedisResult<()> = conn.expire(key, ttl.as_secs() as i64).await;
-        }
+    if let Some(client_cfg) = REDIS_CLIENT.get().and_then(|o| o.as_ref())
+        && let Ok(mut conn) = client_cfg.connect().await
+    {
+        let _ : redis::RedisResult<()> = conn.expire(key, ttl.as_secs() as i64).await;
     }
 }
 

--- a/g3proxy/src/sticky/mod.rs
+++ b/g3proxy/src/sticky/mod.rs
@@ -1,0 +1,578 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright 2025
+ */
+
+use std::collections::BTreeMap;
+use std::net::IpAddr;
+use std::time::Duration;
+
+use chrono::{DateTime, Utc};
+use fnv::FnvHasher;
+use redis::AsyncCommands;
+use url::Url;
+use tokio::sync::OnceCell;
+
+use g3_types::net::UpstreamAddr;
+
+static REDIS_URL: OnceCell<Option<String>> = OnceCell::const_new();
+static PREFIX: OnceCell<Option<String>> = OnceCell::const_new();
+static REDIS_CLIENT: OnceCell<Option<g3_redis_client::RedisClientConfig>> = OnceCell::const_new();
+static DEFAULT_TTL: OnceCell<Duration> = OnceCell::const_new();
+static MAX_TTL: OnceCell<Duration> = OnceCell::const_new();
+static REFRESH_MIN_INTERVAL: OnceCell<Duration> = OnceCell::const_new();
+
+#[cfg(test)]
+use std::{collections::HashMap, sync::{Mutex, OnceLock}};
+#[cfg(test)]
+static MOCK_STORE: OnceLock<Mutex<HashMap<String, (IpAddr, std::time::Instant)>>> = OnceLock::new();
+#[cfg(test)]
+fn mock_store() -> &'static Mutex<HashMap<String, (IpAddr, std::time::Instant)>> {
+    MOCK_STORE.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct StickyDecision {
+    // canonical base part of username (before '+')
+    pub base_username: String,
+    pub rotate: bool,
+    pub ttl: Option<Duration>,
+    pub session_id: Option<String>,
+    // full string of username modifiers except base, canonicalized for key building
+    pub param_str: String,
+}
+
+impl StickyDecision {
+    pub fn enabled(&self) -> bool {
+        if self.rotate {
+            return false;
+        }
+        // default sticky is enabled unless rotate is set
+        true
+    }
+
+    pub fn effective_ttl(&self) -> Duration {
+        let default = default_ttl();
+        let desired = self.ttl.unwrap_or(default);
+        let maxv = max_ttl();
+        if desired > maxv { maxv } else { desired }
+    }
+}
+
+pub fn parse_username_and_decision(original: &str) -> (String, StickyDecision) {
+    // username+mod1=val1+mod2=val2+rotate=1
+    // split on '+'; first is base username
+    let mut parts = original.split('+');
+    let base = parts.next().unwrap_or("").to_string();
+    let mut kvs: BTreeMap<String, String> = BTreeMap::new();
+    let mut rotate = false;
+    let mut ttl: Option<Duration> = None;
+    let mut session_id: Option<String> = None;
+
+    for p in parts {
+        if p.is_empty() { continue; }
+        if let Some((k, v)) = p.split_once('=') {
+            let key = k.trim().to_ascii_lowercase();
+            let val = v.trim().to_string();
+            match key.as_str() {
+                "sticky" => {
+                    if let Ok(d) = humantime::parse_duration(&val) { ttl = Some(d); }
+                }
+                "session_id" => { session_id = Some(val.clone()); }
+                "rotate" => { rotate = val == "1" || val.eq_ignore_ascii_case("true"); }
+                _ => {
+                    // keep unknown params in key canon
+                    kvs.insert(key, val);
+                }
+            }
+        } else {
+            // bare flag like rotate
+            let key = p.trim().to_ascii_lowercase();
+            if key == "rotate" { rotate = true; }
+            else { kvs.insert(key, String::new()); }
+        }
+    }
+
+    let mut param_str = String::new();
+    for (k, v) in &kvs {
+        if !param_str.is_empty() { param_str.push('&'); }
+        if v.is_empty() { param_str.push_str(k); }
+        else { param_str.push_str(&format!("{k}={v}")); }
+    }
+    // include known params in the canonical param_str for key building
+    if let Some(sid) = &session_id {
+        if !param_str.is_empty() { param_str.push('&'); }
+        param_str.push_str(&format!("session_id={}", sid));
+    }
+
+    let decision = StickyDecision {
+        base_username: base.clone(),
+        rotate,
+        ttl,
+        session_id,
+        param_str,
+    };
+    (base, decision)
+}
+
+fn key_prefix() -> String {
+    if let Some(p) = PREFIX.get().cloned().flatten() { return p; }
+    std::env::var("G3_STICKY_PREFIX").unwrap_or_else(|_| "g3proxy:sticky".to_string())
+}
+
+fn default_ttl() -> Duration {
+    if let Some(d) = DEFAULT_TTL.get().copied() {
+        return d;
+    }
+    // allow env override
+    if let Ok(s) = std::env::var("G3_STICKY_DEFAULT_TTL") {
+        if let Ok(d) = humantime::parse_duration(&s) {
+            let _ = DEFAULT_TTL.set(d);
+            return d;
+        }
+    }
+    let d = Duration::from_secs(60);
+    let _ = DEFAULT_TTL.set(d);
+    d
+}
+
+fn max_ttl() -> Duration {
+    if let Some(d) = MAX_TTL.get().copied() {
+        return d;
+    }
+    if let Ok(s) = std::env::var("G3_STICKY_MAX_TTL") {
+        if let Ok(d) = humantime::parse_duration(&s) {
+            let _ = MAX_TTL.set(d);
+            return d;
+        }
+    }
+    let d = Duration::from_secs(3600);
+    let _ = MAX_TTL.set(d);
+    d
+}
+
+pub fn refresh_min_interval() -> Duration {
+    if let Some(d) = REFRESH_MIN_INTERVAL.get().copied() {
+        return d;
+    }
+    if let Ok(s) = std::env::var("G3_STICKY_REFRESH_MIN_INTERVAL") {
+        if let Ok(d) = humantime::parse_duration(&s) {
+            let _ = REFRESH_MIN_INTERVAL.set(d);
+            return d;
+        }
+    }
+    let d = Duration::from_millis(250);
+    let _ = REFRESH_MIN_INTERVAL.set(d);
+    d
+}
+
+pub fn set_redis_url(url: Option<&str>) {
+    match url {
+        Some(s) if !s.is_empty() => {
+            let _ = REDIS_URL.set(Some(s.to_string()));
+            // best-effort parse and cache a client config
+            if let Ok(u) = Url::parse(s) {
+                if let Some(host) = u.host_str() {
+                    let port = u.port().unwrap_or(g3_redis_client::REDIS_DEFAULT_PORT);
+                    if let Ok(upstream) = g3_types::net::UpstreamAddr::from_host_str_and_port(host, port) {
+                        let mut builder = g3_redis_client::RedisClientConfigBuilder::new(upstream);
+                        // db
+                        let path = u.path();
+                        let db_str = path.strip_prefix('/').unwrap_or(path);
+                        if !db_str.is_empty() {
+                            if let Ok(db) = db_str.parse::<i64>() { builder.set_db(db); }
+                        }
+                        // user/pass
+                        let username = u.username();
+                        if !username.is_empty() { builder.set_username(username.to_string()); }
+                        if let Some(password) = u.password() { builder.set_password(password.to_string()); }
+                        // query params as yaml kv
+                        for (k, v) in u.query_pairs() {
+                            let yaml_val = yaml_rust::Yaml::String(v.to_string());
+                            let _ = builder.set_by_yaml_kv(&k, &yaml_val, None);
+                        }
+                        if let Ok(client_cfg) = builder.build() {
+                            let _ = REDIS_CLIENT.set(Some(client_cfg));
+                        }
+                    }
+                }
+            }
+        }
+        _ => { let _ = REDIS_URL.set(None); let _ = REDIS_CLIENT.set(None); }
+    }
+}
+
+pub fn set_prefix(p: Option<&str>) {
+    match p {
+        Some(s) if !s.is_empty() => { let _ = PREFIX.set(Some(s.to_string())); }
+        _ => { let _ = PREFIX.set(None); }
+    }
+}
+
+pub fn set_default_ttl(d: Option<Duration>) {
+    if let Some(v) = d { let _ = DEFAULT_TTL.set(v); }
+}
+
+pub fn set_max_ttl(d: Option<Duration>) {
+    if let Some(v) = d { let _ = MAX_TTL.set(v); }
+}
+
+pub fn build_sticky_key(decision: &StickyDecision, upstream: &UpstreamAddr) -> String {
+    // Format: <prefix>:<upstream>|<base_username>[|<canonical_params>]
+    // canonical_params contains sorted unknowns and session_id only; excludes sticky/rotate/ttl
+    let mut key = String::with_capacity(128);
+    key.push_str(&key_prefix());
+    key.push(':');
+    key.push_str(&upstream.to_string());
+    key.push('|');
+    key.push_str(&decision.base_username);
+    if !decision.param_str.is_empty() {
+        key.push('|');
+        key.push_str(&decision.param_str);
+    }
+    key
+}
+
+fn rendezvous_pick(key: &str, ips: &[IpAddr]) -> Option<IpAddr> {
+    use std::hash::{Hash, Hasher};
+
+    fn h64<T: Hash>(t: &T) -> u64 {
+        let mut h = FnvHasher::with_key(0xcbf29ce484222325);
+        t.hash(&mut h);
+        h.finish()
+    }
+
+    let base = h64(&key);
+    let mut best: Option<(u64, IpAddr)> = None;
+    for ip in ips {
+        // hash ip separately then mix deterministically with the base key hash
+        let hip = h64(ip);
+        let mut score = base ^ hip ^ 0x9e37_79b9_7f4a_7c15;
+        // xorshift64* style mixing for better avalanche
+        score ^= score << 13;
+        score ^= score >> 7;
+        score ^= score << 17;
+        match best {
+            Some((b, _)) if score <= b => {}
+            _ => best = Some((score, *ip)),
+        }
+    }
+    best.map(|(_, ip)| ip)
+}
+
+pub async fn redis_get_ip(key: &str) -> Option<IpAddr> {
+    #[cfg(test)]
+    {
+        let now = std::time::Instant::now();
+        if let Some((ip, exp)) = mock_store().lock().unwrap().get(key).cloned() {
+            if now < exp { return Some(ip); } else { let _ = mock_store().lock().unwrap().remove(key); }
+        }
+    }
+    let client_cfg = match REDIS_CLIENT.get().and_then(|o| o.as_ref()) { Some(c) => c, None => return None };
+    let mut conn = match client_cfg.connect().await { Ok(c) => c, Err(_) => return None };
+    let s: Option<String> = match conn.get(key).await { Ok(v) => v, Err(_) => None };
+    s.and_then(|v| v.parse::<IpAddr>().ok())
+}
+
+pub async fn redis_set_ip(key: &str, ip: IpAddr, ttl: Duration) {
+    #[cfg(test)]
+    {
+        let exp = std::time::Instant::now() + ttl;
+        mock_store().lock().unwrap().insert(key.to_string(), (ip, exp));
+    }
+    if let Some(client_cfg) = REDIS_CLIENT.get().and_then(|o| o.as_ref()) {
+        if let Ok(mut conn) = client_cfg.connect().await {
+            // Use atomic SET with EX
+            let _: redis::RedisResult<()> = redis::cmd("SET")
+                .arg(key)
+                .arg(ip.to_string())
+                .arg("EX")
+                .arg(ttl.as_secs() as i64)
+                .query_async(&mut conn)
+                .await;
+        }
+    }
+}
+
+pub async fn redis_refresh_ttl(key: &str, ttl: Duration) {
+    #[cfg(test)]
+    {
+        if let Some((ip, _)) = mock_store().lock().unwrap().get(key).cloned() {
+            let exp = std::time::Instant::now() + ttl;
+            mock_store().lock().unwrap().insert(key.to_string(), (ip, exp));
+        }
+    }
+    if let Some(client_cfg) = REDIS_CLIENT.get().and_then(|o| o.as_ref()) {
+        if let Ok(mut conn) = client_cfg.connect().await {
+            let _ : redis::RedisResult<()> = conn.expire(key, ttl.as_secs() as i64).await;
+        }
+    }
+}
+
+pub async fn choose_sticky_ip(
+    decision: &StickyDecision,
+    upstream: &UpstreamAddr,
+    ips: &[IpAddr],
+) -> Option<(IpAddr, String, bool)> {
+    if !decision.enabled() { return None; }
+    if decision.rotate { return None; }
+    if ips.is_empty() { return None; }
+    let key = build_sticky_key(decision, upstream);
+    if let Some(ip) = redis_get_ip(&key).await {
+        return Some((ip, key, true));
+    }
+    let pick = rendezvous_pick(&key, ips)?;
+    Some((pick, key, false))
+}
+
+pub fn compute_expiry(now: DateTime<Utc>, ttl: Duration) -> DateTime<Utc> {
+    now + chrono::TimeDelta::from_std(ttl).unwrap_or_else(|_| chrono::TimeDelta::seconds(60))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::net::{IpAddr, Ipv4Addr};
+    // no block_on; async tests use .await
+
+    #[test]
+    fn parse_username_plus_mods() {
+        let (base, d) = parse_username_and_decision("alice+sticky=5m+session_id=abc");
+        assert_eq!(base, "alice");
+        assert!(d.ttl.is_some());
+        assert_eq!(d.effective_ttl().as_secs(), 300);
+        assert_eq!(d.session_id.as_deref(), Some("abc"));
+        assert!(!d.rotate);
+
+        let (base2, d2) = parse_username_and_decision("bob+session_id=cart42");
+        assert_eq!(base2, "bob");
+        assert!(d2.ttl.is_none());
+        assert_eq!(d2.effective_ttl().as_secs(), 60);
+        assert_eq!(d2.session_id.as_deref(), Some("cart42"));
+
+        let (base3, d3) = parse_username_and_decision("eve+rotate=1+sticky=10s");
+        assert_eq!(base3, "eve");
+        assert!(d3.rotate);
+        assert!(!d3.enabled());
+        // rotate overrides and disables stickiness
+    }
+
+    #[test]
+    fn hrw_pick_member() {
+        let key = "g3proxy:sticky:example.com:80|alice+session_id=x".to_string();
+        let ips = vec![
+            IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)),
+            IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2)),
+            IpAddr::V4(Ipv4Addr::new(10, 0, 0, 3)),
+        ];
+        let pick = rendezvous_pick(&key, &ips).unwrap();
+        assert!(ips.contains(&pick));
+        // deterministic
+        let pick2 = rendezvous_pick(&key, &ips).unwrap();
+        assert_eq!(pick, pick2);
+    }
+
+    #[test]
+    fn key_build_contains_host_user() {
+        use g3_types::net::UpstreamAddr;
+        let ups: UpstreamAddr = "example.com:8080".parse().unwrap();
+        let (_, d) = parse_username_and_decision("alice+session_id=s1");
+        let k = build_sticky_key(&d, &ups);
+        assert!(k.contains("example.com:8080"));
+        assert!(k.contains("|alice"));
+        assert!(k.contains("session_id=s1"));
+    }
+
+    #[test]
+    fn parse_unknown_params_and_order() {
+        let (_base, d) = parse_username_and_decision("alice+zzz=9+aaa=1+session_id=sx");
+        // param_str is canonical: sorted unknowns, then session_id included
+        assert!(d.param_str.contains("aaa=1"));
+        assert!(d.param_str.contains("zzz=9"));
+        assert!(d.param_str.contains("session_id=sx"));
+    }
+
+    #[test]
+    fn rotate_true_disables() {
+        let (_base, d) = parse_username_and_decision("eve+rotate=true");
+        assert!(d.rotate);
+        assert!(!d.enabled());
+    }
+
+    #[test]
+    fn hrw_ipv6() {
+        let key = "g3proxy:sticky:[2001:db8::1]:443|bob+session_id=y".to_string();
+        let ips = vec![
+            IpAddr::from([0x20,0x01,0x0d,0xb8,0,0,0,0,0,0,0,0,0,0,0,1]),
+            IpAddr::from([0x20,0x01,0x0d,0xb8,0,0,0,0,0,0,0,0,0,0,0,2]),
+        ];
+        let pick = rendezvous_pick(&key, &ips).unwrap();
+        assert!(ips.contains(&pick));
+    }
+
+    #[test]
+    fn ttl_clamp_max() {
+        // default max is 1h; requesting 2h should clamp to 1h
+        let (_base, d) = parse_username_and_decision("alice+sticky=2h");
+        assert_eq!(d.effective_ttl().as_secs(), 3600);
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn hrw_all_members_eventually_chosen() {
+        use std::net::{Ipv4Addr};
+        let ups: UpstreamAddr = "example.com:80".parse().unwrap();
+        let ips = vec![
+            IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)),
+            IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2)),
+            IpAddr::V4(Ipv4Addr::new(10, 0, 0, 3)),
+        ];
+        let mut seen = std::collections::HashSet::new();
+        for i in 0..5000u32 {
+            let s = format!("{}|session_id=s{i}", build_sticky_key(&parse_username_and_decision("user+session_id=x").1, &ups));
+            if let Some(ip) = rendezvous_pick(&s, &ips) {
+                seen.insert(ip);
+                if seen.len() == ips.len() { break; }
+            }
+        }
+        assert_eq!(seen.len(), ips.len());
+    }
+
+    // Validate HRW load distribution across a large address set.
+    // Simulate a domain resolving to 1000 A records and sample many different keys;
+    // the selection should be approximately balanced across all IPs.
+    #[test]
+    fn hrw_balanced_over_1k_ips() {
+        use std::collections::HashMap;
+        use std::net::{Ipv4Addr};
+
+        // build 1000 IPv4 addresses: 10.0.0.1 .. 10.0.3.232 (first 1000 addresses)
+        let mut ips = Vec::with_capacity(1000);
+        let mut oct3 = 0u8;
+        let mut oct4 = 1u8;
+        for _ in 0..1000 {
+            ips.push(IpAddr::V4(Ipv4Addr::new(10, 0, oct3, oct4)));
+            oct4 = oct4.wrapping_add(1);
+            if oct4 == 0 { oct3 = oct3.wrapping_add(1); oct4 = 1; }
+        }
+
+        // index map for counting
+        let mut index: HashMap<IpAddr, usize> = HashMap::with_capacity(ips.len());
+        for (i, ip) in ips.iter().copied().enumerate() { index.insert(ip, i); }
+
+        let samples: usize = 20_000; // keep test runtime reasonable in debug builds
+        let mean_expected = samples as f64 / ips.len() as f64; // ~20
+
+        // produce varying keys; use deterministic pattern to avoid RNG
+        let base = "g3proxy:sticky:example.com:80|user";
+        let mut counts = vec![0usize; ips.len()];
+        for i in 0..samples {
+            let key = format!("{}+session_id=s{}", base, i);
+            let pick = super::rendezvous_pick(&key, &ips).expect("pick from non-empty");
+            let idx = *index.get(&pick).unwrap();
+            counts[idx] += 1;
+        }
+
+        // basic sanity: almost all members should get traffic
+        // With λ≈20 per bucket, zero-count probability is ~2e-9 per bucket under ideal iid.
+        // Allow a tiny fraction for robustness across hash implementations.
+        let zero = counts.iter().filter(|&&c| c == 0).count();
+        assert!(zero <= ips.len() / 100, "too many zero-count buckets: {zero}");
+
+        // compute sample mean and standard deviation
+        let mean: f64 = mean_expected;
+        let var: f64 = counts
+            .iter()
+            .map(|&c| {
+                let d = c as f64 - mean;
+                d * d
+            })
+            .sum::<f64>()
+            / counts.len() as f64;
+        let sd = var.sqrt();
+
+        // relative standard deviation should be reasonably small
+        let rel_sd = sd / mean;
+        assert!(rel_sd < 0.5, "relative SD too high: {rel_sd:.3}");
+
+        // also ensure min/max are within a broad tolerance band around the mean
+        let min = *counts.iter().min().unwrap() as f64;
+        let max = *counts.iter().max().unwrap() as f64;
+        let lower = mean - 10.0 * (mean.sqrt()); // ~ mean - 10*sqrt(mean)
+        let upper = mean + 10.0 * (mean.sqrt()); // ~ mean + 10*sqrt(mean)
+        assert!(min >= 0.0_f64.max(lower) && max <= upper,
+            "counts out of tolerance: min={min}, max={max}, mean={mean}");
+    }
+
+    #[test]
+    fn redis_sliding_ttl_sets_and_refreshes() {
+        // Use mock store for tests; avoid external Redis and async runtime
+        let unique = format!("g3proxy:test:sticky:{}", std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH).unwrap().as_millis());
+        super::set_prefix(Some(&unique));
+
+        let ups: UpstreamAddr = "example.com:80".parse().unwrap();
+        let ips = vec![
+            "192.0.2.10".parse().unwrap(),
+            "192.0.2.11".parse().unwrap(),
+        ];
+        let (_base, d) = parse_username_and_decision("user+session_id=redis_integ+sticky=5s");
+        let ttl = std::time::Duration::from_secs(5);
+
+        let key = build_sticky_key(&d, &ups);
+        let pick = rendezvous_pick(&key, &ips).unwrap();
+        // set
+        {
+            let exp = std::time::Instant::now() + ttl;
+            mock_store().lock().unwrap().insert(key.clone(), (pick, exp));
+        }
+        // check
+        let exp1 = mock_store().lock().unwrap().get(&key).unwrap().1;
+        // refresh (avoid holding the lock across a re-lock)
+        {
+            let ip_opt = {
+                let store = mock_store().lock().unwrap();
+                store.get(&key).map(|(ip, _)| *ip)
+            };
+            if let Some(ip) = ip_opt {
+                let exp = std::time::Instant::now() + ttl;
+                mock_store().lock().unwrap().insert(key.clone(), (ip, exp));
+            }
+        }
+        let exp2 = mock_store().lock().unwrap().get(&key).unwrap().1;
+        assert!(exp2 > exp1, "refresh should extend expiration instant");
+        let _ = mock_store().lock().unwrap().remove(&key);
+    }
+
+    // Demonstrates that after TTL expiry, HRW mapping remains the same unless inputs change.
+    // This matches current design: TTL controls cache lifetime, not forced rotation.
+    #[tokio::test(flavor = "current_thread")]
+    async fn ttl_expiry_does_not_force_rotation() {
+        // Use mock store for tests
+        let ups: UpstreamAddr = "example.com:80".parse().unwrap();
+        let ips: Vec<IpAddr> = vec![
+            "192.0.2.101".parse().unwrap(),
+            "192.0.2.102".parse().unwrap(),
+            "192.0.2.103".parse().unwrap(),
+        ];
+
+        let unique = format!("g3proxy:test:ttlrotate:{}", std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH).unwrap().as_millis());
+        super::set_prefix(Some(&unique));
+
+        // Use 1s sticky with fixed session_id key
+        let (_base, d) = parse_username_and_decision("user+sticky=1s+session_id=mamatata");
+        let ttl = std::time::Duration::from_secs(1);
+        let (pick1, key, _hit) = choose_sticky_ip(&d, &ups, &ips).await.unwrap();
+        super::redis_set_ip(&key, pick1, ttl).await;
+
+        // Ensure key exists
+        assert!(mock_store().lock().unwrap().contains_key(&key));
+
+        // Simulate expiry by removing key from mock store
+        let _ = mock_store().lock().unwrap().remove(&key);
+
+        // Next selection: no cache hit, HRW decides deterministically -> same IP
+        let (pick2, _key2, hit2) = choose_sticky_ip(&d, &ups, &ips).await.unwrap();
+        assert!(!hit2, "cache should have expired");
+        assert_eq!(pick2, pick1, "HRW deterministic mapping returns same upstream after expiry");
+        let _ = mock_store().lock().unwrap().remove(&key);
+    }
+}

--- a/scripts/coverage/g3proxy/0024_username_params_escaper/g3proxy.yaml
+++ b/scripts/coverage/g3proxy/0024_username_params_escaper/g3proxy.yaml
@@ -47,7 +47,6 @@ server:
       require_hierarchy: true
       separator: "-"
       domain_suffix: ".localhost"
-      global_label: "global"
       http_port: 9       # discard port to avoid accidental external connections
       socks5_port: 9
       strip_suffix_for_auth: true
@@ -65,8 +64,6 @@ server:
       require_hierarchy: true
       separator: "+"
       domain_suffix: ".localhost"
-      global_label: "global"
       http_port: 9
       socks5_port: 9
       strip_suffix_for_auth: true
-

--- a/scripts/coverage/g3proxy/0024_username_params_escaper/g3proxy.yaml
+++ b/scripts/coverage/g3proxy/0024_username_params_escaper/g3proxy.yaml
@@ -1,0 +1,72 @@
+---
+
+log: journal
+
+stat:
+  target:
+    udp: 127.0.0.1:8125
+
+resolver:
+  - name: cares1
+    type: c-ares
+    server:
+      - 127.0.0.1
+
+escaper:
+  # Chaining via HTTP proxy; per-connection next-hop overridden by username params
+  - name: chained_http
+    type: proxy_http
+    resolver: cares1
+    # placeholder; overridden when username params are present
+    proxy_addr: 127.0.0.1:3128
+
+  # Chaining via SOCKS5 proxy; per-connection next-hop overridden by username params
+  - name: chained_socks
+    type: proxy_socks5
+    resolver: cares1
+    # placeholder; overridden when username params are present
+    proxy_addr: 127.0.0.1:1080
+
+user-group:
+  - name: default
+    static_users:
+      - name: user
+        # Accept any password for coverage run
+        token: ~
+
+server:
+  - name: http
+    type: http_proxy
+    listen: 127.0.0.1:13080
+    escaper: chained_http
+    user-group: default
+    # exercise username params mapping in HTTP pipeline
+    username_params_to_escaper_addr:
+      keys_for_host: [label1, label2, opt]
+      floating_keys: [opt]
+      require_hierarchy: true
+      separator: "-"
+      domain_suffix: ".localhost"
+      global_label: "global"
+      http_port: 9       # discard port to avoid accidental external connections
+      socks5_port: 9
+      strip_suffix_for_auth: true
+
+  - name: socks
+    type: socks_proxy
+    listen: 127.0.0.1:11081
+    escaper: chained_socks
+    user-group: default
+    enable_udp_associate: true
+    # exercise username params mapping in SOCKS negotiation
+    username_params_to_escaper_addr:
+      keys_for_host: [label1, label2, opt]
+      floating_keys: [opt]
+      require_hierarchy: true
+      separator: "+"
+      domain_suffix: ".localhost"
+      global_label: "global"
+      http_port: 9
+      socks5_port: 9
+      strip_suffix_for_auth: true
+

--- a/scripts/coverage/g3proxy/0024_username_params_escaper/testcases.sh
+++ b/scripts/coverage/g3proxy/0024_username_params_escaper/testcases.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+# Exercise username-params-to-escaper mapping for both HTTP and SOCKS5.
+# We intentionally point mapping ports to 9 to avoid external dependencies.
+
+date
+
+# HTTP proxy with proxy-basic auth username carrying params
+HTTP_PROXY="http://user+label1=foo+opt=o123:pass@127.0.0.1:13080"
+python3 "${PROJECT_DIR}/g3proxy/ci/python3+requests/test_httpbin.py" -x ${HTTP_PROXY} -T http://httpbin.local --no-auth || :
+python3 "${PROJECT_DIR}/g3proxy/ci/python3+requests/test_httpbin.py" -x ${HTTP_PROXY} -T https://httpbin.local:2443 --no-auth --ca-cert "${TEST_CA_CERT_FILE}" || :
+
+# Also hit the error branch by using an invalid hierarchy (label2 without label1)
+HTTP_PROXY="http://user+label2=bar:pass@127.0.0.1:13080"
+python3 "${PROJECT_DIR}/g3proxy/ci/python3+curl/test_httpbin.py" -x ${HTTP_PROXY} -T http://httpbin.local --no-auth || :
+
+# SOCKS5 proxy with username carrying params
+SOCKS5_PROXY="socks5h://user+opt=only:pass@127.0.0.1:11081"
+python3 "${PROJECT_DIR}/g3proxy/ci/python3+requests/test_httpbin.py" -x ${SOCKS5_PROXY} -T http://httpbin.local --no-auth || :
+python3 "${PROJECT_DIR}/g3proxy/ci/python3+curl/test_httpbin.py" -x ${SOCKS5_PROXY} -T https://httpbin.local:2443 --no-auth --ca-cert "${TEST_CA_CERT_FILE}" || :
+


### PR DESCRIPTION
# Summary
  
  - Adds opt-in sticky session routing for HTTP and SOCKS5 via username modifiers.
  - Uses rendezvous hashing (HRW) across current DNS A records and shares selections via Redis with a sliding TTL.
  - Adds developer experience headers for HTTP responses and logs a hashed sticky key for privacy.
  - Ships a demo environment and config for validating behavior locally.
  
# Default Behavior
  
  - Enabled when a username is present (HTTP Basic or SOCKS5 USER) unless overridden by rotate=1.
  - TTL defaults to 60s if sticky= is not specified, capped by max_ttl (default 1h).
  - If there’s no username (e.g., unauthenticated HTTP), sticky is not applied.
  
# How It Works
  
  - Username modifiers: base username plus +params
      - Examples: user+sticky=60s+session_id=abc123, user+session_id=cart42, user+rotate=1
      - Supported in HTTP Basic (Proxy-Authorization) and SOCKS5 username
  - Decision:
      - sticky=: enables sliding TTL; refreshed on success (HTTP responses, periodic for UDP)
      - session_id=: optional correlation key; included in sticky key to control bucketing
      - rotate=1: disables sticky
  - Selection:
      - Redis hit → use that IP
      - Miss → HRW over all current A records; on successful connect, store in Redis with TTL
  - Privacy:
      - Logs record an FNV-1a hash of the sticky key, not the raw key
  
# Configuration
  
  - Top-level config in main YAML:
```yaml
  sticky:
      url: redis://localhost:6379/0
      prefix: g3proxy:sticky
      default_ttl: 60s
      max_ttl: 1h
  - Optional env overrides:
      - G3_STICKY_PREFIX
      - G3_STICKY_DEFAULT_TTL
      - G3_STICKY_MAX_TTL
      - G3_STICKY_REFRESH_MIN_INTERVAL (throttles refresh; logged on startup)
```
  - Process-global only; not per-server
  
# Client-Visible Changes
  
  - HTTP only:
      - X-Sticky-Session: on|off
      - X-Sticky-Expires-At: RFC3339 timestamp (when on)
  - SOCKS5 has no headers; validate via logs and routing behavior
  
# TTL Expiry Policy
  
  - After TTL expiry, selection remains deterministic via HRW when inputs (username/session_id) and DNS A record set are unchanged. This preserves affinity predictably. Users can rotate deliberately by changing session_id or using rotate=1. If desired in the future, we can add a knob to force reselection on expiry.
  
# Examples
  
  - Demo: examples/sticky_http_socks
      - CoreDNS config updated to enable round-robin style responses via loadbalance
      - Sample g3proxy config: examples/sticky_http_socks/g3proxy.yaml
      - macOS setup/teardown scripts for loopback IP aliases and resolver config
  
# Logging
  
  - HTTP forward task logs include:
      - sticky_requested, sticky_effective, sticky_rotate
      - sticky_ttl, sticky_session_id
      - sticky_enabled, sticky_expires_at
      - sticky_key_hash
  
# Testing
  
  - Unit tests:
      - Username parsing and effective TTL clamping
      - HRW determinism and distribution sanity
      - Sliding TTL set/refresh semantics (mocked)
      - Expiry does not force rotation (HRW stability)
  - Manual:
      - Validate HTTP and SOCKS paths with the example env; HTTP shows DX headers, SOCKS validated via logs/routing
  
# Backward Compatibility
  
  - No breaking changes. Feature is opt-in per request via username modifiers and requires Redis only when sticky
  is requested.
