### PR TITLE
Update dev-setup.md

### DIFF
--- a/doc/dev-setup.md
+++ b/doc/dev-setup.md
@@ -184,7 +184,7 @@ winget install NASM.NASM Ninja-build.Ninja
 # install libraries
 vcpkg install --triplet=x64-windows-static-md openssl
 # build, c-ares need to be vendored, lua and python feature need to be disabled
-cargo build --no-default-features --features quic,vendored-c-ares,hickory
+cargo build --no-default-features --features quic,vendored-c-ares,rustls-aws-lc
 ```
 
 **Tips**


### PR DESCRIPTION
Wont compile without missing Rustls backend dependency of either rustls-aws-lc or rustls-ring.

Removing hickory from install argument because of error in compile time.

```
error: none of the selected packages contains this feature: hickory
selected packages: g3bench, g3fcgen, g3iploc, g3keymess, g3keymess-proto, g3keymess-ctl, g3mkcert, g3proxy, g3proxy-ctl, g3proxy-ftp, g3proxy-lua, g3statsd, g3statsd-ctl, g3tiles, g3tiles-ctl, capnp-generate
help: package with the missing feature: g3-resolver
```

Upon further review it does look like the build system neither g3proxy nor g3proxy-ctl has a feature literally named "vendored" defined in their Cargo.toml.

That feature belongs to the mlua crate, which g3proxy uses.

So perhaps g3proxy needs to add vendored as a feature?

See my chat with Gemini re this here: https://g.co/gemini/share/9232c5eeb261