### PR TITLE
g3proxy: h2 idle tasks shutdown

### DIFF
--- a/g3proxy/src/inspect/http/v2/mod.rs
+++ b/g3proxy/src/inspect/http/v2/mod.rs
@@ -400,8 +400,6 @@ where
         };
 
         let mut idle_interval = self.ctx.idle_wheel.register();
-        idle_interval.skip_missed_ticks();
-
         let mut idle_count = 0;
 
         loop {

--- a/g3proxy/src/inspect/http/v2/stats.rs
+++ b/g3proxy/src/inspect/http/v2/stats.rs
@@ -22,11 +22,11 @@ impl Default for H2ConcurrencyStats {
 impl H2ConcurrencyStats {
     pub(super) fn add_task(&self) {
         self.total_task.fetch_add(1, Ordering::Relaxed);
-        self.alive_task.fetch_add(1, Ordering::Relaxed);
+        self.alive_task.fetch_add(1, Ordering::Release);
     }
 
     pub(super) fn del_task(&self) {
-        self.alive_task.fetch_sub(1, Ordering::Relaxed);
+        self.alive_task.fetch_sub(1, Ordering::Release);
     }
 
     pub(super) fn get_total_task(&self) -> u64 {
@@ -34,6 +34,6 @@ impl H2ConcurrencyStats {
     }
 
     pub(super) fn get_alive_task(&self) -> i32 {
-        self.alive_task.load(Ordering::Relaxed)
+        self.alive_task.load(Ordering::Acquire)
     }
 }

--- a/lib/g3-io-ext/src/time/idle.rs
+++ b/lib/g3-io-ext/src/time/idle.rs
@@ -6,7 +6,7 @@
 use std::sync::Arc;
 use std::time::Duration;
 
-use tokio::time::{Instant, Interval};
+use tokio::time::{Instant, Interval, MissedTickBehavior};
 
 pub struct IdleWheel {
     interval: Duration,
@@ -36,6 +36,11 @@ impl IdleInterval {
 
     pub fn period(&self) -> Duration {
         self.interval.period()
+    }
+
+    pub fn skip_missed_ticks(&mut self) {
+        self.interval
+            .set_missed_tick_behavior(MissedTickBehavior::Delay);
     }
 }
 

--- a/lib/g3-io-ext/src/time/idle.rs
+++ b/lib/g3-io-ext/src/time/idle.rs
@@ -18,9 +18,9 @@ impl IdleWheel {
     }
 
     pub fn register(&self) -> IdleInterval {
-        IdleInterval {
-            interval: tokio::time::interval_at(Instant::now() + self.interval, self.interval),
-        }
+        let mut x_idle = tokio::time::interval_at(Instant::now() + self.interval, self.interval);
+        x_idle.set_missed_tick_behavior(MissedTickBehavior::Delay);
+        IdleInterval { interval: x_idle }
     }
 }
 
@@ -36,11 +36,6 @@ impl IdleInterval {
 
     pub fn period(&self) -> Duration {
         self.interval.period()
-    }
-
-    pub fn skip_missed_ticks(&mut self) {
-        self.interval
-            .set_missed_tick_behavior(MissedTickBehavior::Delay);
     }
 }
 


### PR DESCRIPTION
We found some h2 tasks closing abruptly, I think the following changes can help improve the task idle checks for both h2 task and inner-stream forwarding tasks. 

1. For `tokio::select!` with many active event triggers, the default behavior for the `IdleWheel` timer is to catch up in bursts to all missed ticks. Setting `MissedTickBehavior::Delay` for our interval timer guarantees we maintain a regular period between each interval check and thus respect the total idle timeout duration for a task -- [tokio: set_missed_tick_behavior](https://docs.rs/tokio/latest/tokio/time/enum.MissedTickBehavior.html#:~:text=Tick%20at%20multiples%20of%20period,period%20from%20start%20any%20longer.) 

    Besides h2 task interval check, I feel this behavior might make sense for most of the other idle task checking scenarios?

2. Moved active h2 inner streaming tasks counter type from `Relaxed` to `Acquire/Release` to avoid race conditions in abruptly closing in-progress sub tasks.

3. Propose setting h2 idle connection shutdown reason to `NO_ERROR` as we close the idle connection as intended without any errors.