### PR TITLE
fix: icap payload length parsing with atoi FromRadix10

### DIFF
--- a/lib/g3-icap-client/src/reqmod/payload.rs
+++ b/lib/g3-icap-client/src/reqmod/payload.rs
@@ -47,7 +47,8 @@ impl IcapReqmodResponsePayload {
                         .ok_or(IcapReqmodParseError::UnsupportedBody(
                             "invalid body byte-offsets pair",
                         ))?;
-                let (hdr_len, offset) = usize::from_radix_10(value.as_bytes());
+                let (hdr_len, offset) = u32::from_radix_10(value.as_bytes());
+                let hdr_len = hdr_len as usize;
                 if offset != value.len() {
                     return Err(IcapReqmodParseError::UnsupportedBody(
                         "invalid body byte-offsets value",
@@ -74,7 +75,8 @@ impl IcapReqmodResponsePayload {
                         .ok_or(IcapReqmodParseError::UnsupportedBody(
                             "invalid body byte-offsets pair",
                         ))?;
-                let (hdr_len, offset) = usize::from_radix_10(value.as_bytes());
+                let (hdr_len, offset) = u32::from_radix_10(value.as_bytes());
+                let hdr_len = hdr_len as usize;
                 if offset != value.len() {
                     return Err(IcapReqmodParseError::UnsupportedBody(
                         "invalid body byte-offsets value",

--- a/lib/g3-icap-client/src/respmod/payload.rs
+++ b/lib/g3-icap-client/src/respmod/payload.rs
@@ -45,7 +45,8 @@ impl IcapRespmodResponsePayload {
                         .ok_or(IcapRespmodParseError::UnsupportedBody(
                             "invalid body byte-offsets pair",
                         ))?;
-                let (hdr_len, offset) = usize::from_radix_10(value.as_bytes());
+                let (hdr_len, offset) = u32::from_radix_10(value.as_bytes());
+                let hdr_len = hdr_len as usize;
                 if offset != value.len() {
                     return Err(IcapRespmodParseError::UnsupportedBody(
                         "invalid body byte-offsets value",


### PR DESCRIPTION
avoid using `usize::from_radix_10` 