### PR TITLE
docs: constrain Sphinx below version 9

### DIFF
--- a/sphinx/requirements.txt
+++ b/sphinx/requirements.txt
@@ -1,3 +1,3 @@
-sphinx
+sphinx<9
 sphinx-multiproject
 sphinx-rtd-theme


### PR DESCRIPTION
## Summary

- constrain Sphinx to the latest compatible major version for `sphinx-multiproject` 1.0.0
- restore the multiproject documentation build used by all five Read the Docs projects

Fixes #1109.

## Testing

- `uv run --python 3.13 --with-requirements sphinx/requirements.txt sphinx-build --version` (resolved Sphinx 8.2.3)
- `uv run --python 3.13 --with-requirements sphinx/requirements.txt sphinx-build -q -b html sphinx <output-directory>`
- `uv run --python 3.13 --with-requirements sphinx/requirements.txt sphinx-build -W -n -q -b html sphinx/g3proxy <output-directory>`
- `uv run --python 3.13 --with-requirements sphinx/requirements.txt sphinx-build -W -n -q -b html sphinx/g3statsd <output-directory>`
- `uv run --python 3.13 --with-requirements sphinx/requirements.txt sphinx-build -W -n -q -b html sphinx/g3tiles <output-directory>`
- `uv run --python 3.13 --with-requirements sphinx/requirements.txt sphinx-build -W -n -q -b html sphinx/g3keymess <output-directory>`