### PR TITLE
ci: fix Rust 1.97 clippy errors

### DIFF
--- a/g3fcgen/src/main.rs
+++ b/g3fcgen/src/main.rs
@@ -22,7 +22,7 @@ fn main() -> anyhow::Result<()> {
 
     g3_daemon::runtime::config::set_default_thread_number(0); // default to use current thread
     let config_file = g3fcgen::config::load()
-        .context(format!("failed to load config, opts: {:?}", &proc_args))?;
+        .context(format!("failed to load config, opts: {:?}", proc_args))?;
     debug!("loaded config from {}", config_file.display());
 
     if proc_args.daemon_config.test_config {

--- a/lib/g3-slog-types/src/net.rs
+++ b/lib/g3-slog-types/src/net.rs
@@ -47,7 +47,7 @@ impl Value for LtUpstreamAddr<'_> {
         if self.0.is_empty() {
             serializer.emit_none(key)
         } else {
-            serializer.emit_arguments(key, &format_args!("{}", &self.0))
+            serializer.emit_arguments(key, &format_args!("{}", self.0))
         }
     }
 }


### PR DESCRIPTION
## Summary

- remove the redundant formatting borrow in `LtUpstreamAddr`
- remove the redundant formatting borrow from the g3fcgen config error context
- allow the Rust 1.97 Clippy checks to proceed past both `useless_borrows_in_formatting` errors

Fixes #1111.

## Testing

On Windows x86_64-pc-windows-msvc with Rust 1.97.0 / Clippy 0.1.97:

- `cargo +1.97.0 clippy -p g3-slog-types --all-targets --locked -- --deny warnings`
- `cargo +1.97.0 test -p g3-slog-types --all-targets --locked`
- `cargo +1.97.0 clippy --no-default-features --features vendored-aws-lc -p g3fcgen --locked -- --deny warnings`
- `cargo +1.97.0 test --no-default-features --features vendored-aws-lc -p g3fcgen --locked`
- `git diff --check`

The g3fcgen commands used the workflow's `AWS_LC_SYS_PREBUILT_NASM=1` setting and the Visual Studio C++/CMake/LLVM toolchain. Both targeted crates currently contain zero unit tests; their test builds and g3fcgen doctests completed successfully.