### PR TITLE
docs: fix VEY links in Sphinx indexes

### DIFF
--- a/sphinx/g3keymess/index.rst
+++ b/sphinx/g3keymess/index.rst
@@ -1,8 +1,8 @@
 Welcome to g3keymess's documentation!
 =====================================
 
-**The G3 project is now in maintenance mode, and active development has been moved to
-the [VEY](https://github.com/VEY-OSS/vey) project.**
+**The G3 project is now in maintenance mode, and active development has been moved to the**
+`VEY <https://github.com/VEY-OSS/vey>`_ **project.**
 
 .. toctree::
    :maxdepth: 1

--- a/sphinx/g3proxy/index.rst
+++ b/sphinx/g3proxy/index.rst
@@ -1,8 +1,8 @@
 Welcome to g3proxy's documentation!
 ===================================
 
-**The G3 project is now in maintenance mode, and active development has been moved to
-the [VEY](https://github.com/VEY-OSS/vey) project.**
+**The G3 project is now in maintenance mode, and active development has been moved to the**
+`VEY <https://github.com/VEY-OSS/vey>`_ **project.**
 
 .. toctree::
    :maxdepth: 1

--- a/sphinx/g3statsd/index.rst
+++ b/sphinx/g3statsd/index.rst
@@ -1,8 +1,8 @@
 Welcome to g3statsd's documentation!
 ====================================
 
-**The G3 project is now in maintenance mode, and active development has been moved to
-the [VEY](https://github.com/VEY-OSS/vey) project.**
+**The G3 project is now in maintenance mode, and active development has been moved to the**
+`VEY <https://github.com/VEY-OSS/vey>`_ **project.**
 
 .. toctree::
    :maxdepth: 1

--- a/sphinx/g3tiles/index.rst
+++ b/sphinx/g3tiles/index.rst
@@ -1,8 +1,8 @@
 Welcome to g3tiles's documentation!
 ===================================
 
-**The G3 project is now in maintenance mode, and active development has been moved to
-the [VEY](https://github.com/VEY-OSS/vey) project.**
+**The G3 project is now in maintenance mode, and active development has been moved to the**
+`VEY <https://github.com/VEY-OSS/vey>`_ **project.**
 
 .. toctree::
    :maxdepth: 1


### PR DESCRIPTION
## Summary

- replace Markdown-style VEY links with reStructuredText links
- update all four component index sources together
- preserve the maintenance banner while making the migration link clickable

Fixes #1113.

## Testing

For each of `g3proxy`, `g3statsd`, `g3tiles`, and `g3keymess`:

- `uv run --with-requirements sphinx/requirements.txt sphinx-build -W -n -q -b html sphinx/<component> <output-directory>`
- verified the generated `index.html` contains `href="https://github.com/VEY-OSS/vey"`
- verified the generated `index.html` no longer contains the literal Markdown link text