### PR TITLE
g3-fluentd: parse retry_queue_len from yaml

### DIFF
--- a/lib/g3-fluentd/src/config/yaml.rs
+++ b/lib/g3-fluentd/src/config/yaml.rs
@@ -96,6 +96,12 @@ impl FluentdClientConfig {
                         config.set_flush_interval(interval);
                         Ok(())
                     }
+                    "retry_queue_len" => {
+                        let len = g3_yaml::value::as_usize(v)
+                            .context(format!("invalid usize value for key {k}"))?;
+                        config.set_retry_queue_len(len);
+                        Ok(())
+                    }
                     _ => Err(anyhow!("invalid key {k}")),
                 })?;
 
@@ -144,6 +150,7 @@ mod tests {
                 connect_delay: "1s"
                 write_timeout: "500ms"
                 flush_interval: "100ms"
+                retry_queue_len: 64
             "#
         );
         let config = FluentdClientConfig::parse_yaml(&yaml, None).unwrap();
@@ -171,6 +178,7 @@ mod tests {
         assert_eq!(config.connect_delay, std::time::Duration::from_secs(1));
         assert_eq!(config.write_timeout, std::time::Duration::from_millis(500));
         assert_eq!(config.flush_interval, std::time::Duration::from_millis(100));
+        assert_eq!(config.retry_queue_len, 64);
 
         let yaml = yaml_doc!(
             r#"


### PR DESCRIPTION
## Summary

- parse the documented `retry_queue_len` Fluentd YAML option as a `usize`
- pass the parsed value to the existing `set_retry_queue_len` configuration hook
- extend the Fluentd YAML parser test to verify the configured queue length

The three existing Fluentd driver pages already document this option, so no documentation source changes are needed.

Fixes #1118.

## Testing

On Windows x86_64-pc-windows-msvc with Rust 1.97.0:

- `cargo +1.97.0 fmt --all -- --check`
- `cargo +1.97.0 test -p g3-fluentd -p g3fcgen --features g3-fluentd/yaml,g3fcgen/vendored-aws-lc --locked` (8 g3-fluentd tests passed; selected g3fcgen and doctest targets also passed)
- `cargo +1.97.0 clippy -p g3-fluentd -p g3fcgen --features g3-fluentd/yaml,g3fcgen/vendored-aws-lc --all-targets --locked -- --deny warnings --allow clippy::useless_borrows_in_formatting`
- `git diff --check`

The narrow Clippy allow is for the two unrelated upstream `g3fcgen`/`g3-slog-types` Rust 1.97 findings tracked in #1111 and fixed separately by #1112; `g3-fluentd` remains checked with warnings denied.