### PR TITLE
daemon: add cross-platform reload commands

### DIFF
--- a/g3keymess/proto/schema/proc.capnp
+++ b/g3keymess/proto/schema/proc.capnp
@@ -9,6 +9,7 @@ interface ProcControl {
 
   version @0 () -> (version :Text);
   offline @1 () -> (result :Types.OperationResult);
+  reload @10 () -> (result :Types.OperationResult);
   cancelShutdown @8 () -> (result :Types.OperationResult);
   releaseController @9 () -> (result :Types.OperationResult);
 

--- a/g3keymess/src/control/bridge/mod.rs
+++ b/g3keymess/src/control/bridge/mod.rs
@@ -6,6 +6,10 @@
 use anyhow::anyhow;
 use openssl::pkey::PKey;
 
+pub(crate) async fn reload() -> anyhow::Result<()> {
+    run_in_main_thread(crate::signal::reload()).await
+}
+
 pub(crate) async fn add_key(pem: &str) -> anyhow::Result<()> {
     let key = PKey::private_key_from_pem(pem.as_bytes())
         .map_err(|e| anyhow!("invalid private key content: {e}"))?;

--- a/g3keymess/src/control/capnp/proc.rs
+++ b/g3keymess/src/control/capnp/proc.rs
@@ -38,6 +38,16 @@ impl proc_control::Server for ProcControlImpl {
         Ok(())
     }
 
+    async fn reload(
+        self: Rc<Self>,
+        _params: proc_control::ReloadParams,
+        mut results: proc_control::ReloadResults,
+    ) -> capnp::Result<()> {
+        let r = crate::control::bridge::reload().await;
+        set_operation_result(results.get().init_result(), r);
+        Ok(())
+    }
+
     async fn cancel_shutdown(
         self: Rc<Self>,
         _params: proc_control::CancelShutdownParams,

--- a/g3keymess/src/signal.rs
+++ b/g3keymess/src/signal.rs
@@ -3,30 +3,44 @@
  * Copyright 2023-2025 ByteDance and/or its affiliates.
  */
 
-use log::{error, info, warn};
+use anyhow::Context;
+use log::{info, warn};
 use tokio::sync::Mutex;
 
 use g3_daemon::signal::AsyncSignalAction;
 
 static RELOAD_MUTEX: Mutex<()> = Mutex::const_new(());
 
-async fn do_reload() {
+pub(super) async fn reload() -> anyhow::Result<()> {
     let _guard = RELOAD_MUTEX.lock().await;
     info!("reloading config");
 
-    if let Err(e) = crate::config::reload().await {
-        warn!("error reloading config: {e:?}");
-        warn!("reload aborted");
+    match reload_locked().await {
+        Ok(_) => {
+            info!("reload finished");
+            Ok(())
+        }
+        Err(e) => {
+            warn!("reload error: {e:?}");
+            warn!("reload aborted");
+            Err(e)
+        }
     }
+}
 
-    if let Err(e) = crate::store::reload_all().await {
-        error!("failed to reload all key store: {e:?}");
-    }
-    if let Err(e) = crate::serve::spawn_all().await {
-        error!("failed to reload all servers: {e:?}");
-    }
+async fn reload_locked() -> anyhow::Result<()> {
+    crate::config::reload()
+        .await
+        .context("failed to reload config")?;
 
-    info!("reload finished");
+    crate::store::reload_all()
+        .await
+        .context("failed to reload all key stores")?;
+    crate::serve::spawn_all()
+        .await
+        .context("failed to reload all servers")?;
+
+    Ok(())
 }
 
 #[derive(Clone, Copy)]
@@ -38,30 +52,37 @@ impl AsyncSignalAction for QuitAction {
     }
 }
 
-#[allow(unused)]
-#[derive(Clone, Copy)]
-struct OfflineAction {}
+#[cfg(unix)]
+mod unix {
+    use g3_daemon::signal::AsyncSignalAction;
 
-impl AsyncSignalAction for OfflineAction {
-    async fn run(&self) {
-        g3_daemon::control::quit::start_graceful_shutdown().await;
+    #[derive(Clone, Copy)]
+    struct OfflineAction {}
+
+    impl AsyncSignalAction for OfflineAction {
+        async fn run(&self) {
+            g3_daemon::control::quit::start_graceful_shutdown().await;
+        }
     }
-}
 
-#[allow(unused)]
-#[derive(Clone, Copy)]
-struct ReloadAction {}
+    #[derive(Clone, Copy)]
+    struct ReloadAction {}
 
-impl AsyncSignalAction for ReloadAction {
-    async fn run(&self) {
-        do_reload().await
+    impl AsyncSignalAction for ReloadAction {
+        async fn run(&self) {
+            let _ = super::reload().await;
+        }
+    }
+
+    pub(super) fn register() -> anyhow::Result<()> {
+        g3_daemon::signal::register_offline(OfflineAction {})?;
+        g3_daemon::signal::register_reload(ReloadAction {})?;
+        Ok(())
     }
 }
 
 pub fn register() -> anyhow::Result<()> {
     #[cfg(unix)]
-    g3_daemon::signal::register_offline(OfflineAction {})?;
-    #[cfg(unix)]
-    g3_daemon::signal::register_reload(ReloadAction {})?;
+    unix::register()?;
     g3_daemon::signal::register_quit(QuitAction {})
 }

--- a/g3keymess/utils/ctl/src/main.rs
+++ b/g3keymess/utils/ctl/src/main.rs
@@ -22,6 +22,7 @@ fn build_cli_args() -> Command {
         .append_daemon_ctl_args()
         .subcommand(proc::commands::version())
         .subcommand(proc::commands::offline())
+        .subcommand(proc::commands::reload())
         .subcommand(proc::commands::cancel_shutdown())
         .subcommand(proc::commands::list())
         .subcommand(proc::commands::publish_key())
@@ -55,6 +56,7 @@ async fn main() -> anyhow::Result<()> {
             match subcommand {
                 proc::COMMAND_VERSION => proc::version(&proc_control).await,
                 proc::COMMAND_OFFLINE => proc::offline(&proc_control).await,
+                proc::COMMAND_RELOAD => proc::reload(&proc_control).await,
                 proc::COMMAND_CANCEL_SHUTDOWN => proc::cancel_shutdown(&proc_control).await,
                 proc::COMMAND_LIST => proc::list(&proc_control, args).await,
                 proc::COMMAND_PUBLISH_KEY => proc::publish_key(&proc_control, args).await,

--- a/g3keymess/utils/ctl/src/proc.rs
+++ b/g3keymess/utils/ctl/src/proc.rs
@@ -19,6 +19,7 @@ use crate::common::{parse_fetch_result, parse_operation_result};
 
 pub const COMMAND_VERSION: &str = "version";
 pub const COMMAND_OFFLINE: &str = "offline";
+pub const COMMAND_RELOAD: &str = "reload";
 pub const COMMAND_CANCEL_SHUTDOWN: &str = "cancel-shutdown";
 pub const COMMAND_LIST: &str = "list";
 pub const COMMAND_PUBLISH_KEY: &str = "publish-key";
@@ -40,6 +41,10 @@ pub mod commands {
 
     pub fn offline() -> Command {
         Command::new(COMMAND_OFFLINE).about("Put this daemon into offline mode")
+    }
+
+    pub fn reload() -> Command {
+        Command::new(COMMAND_RELOAD).about("Reload the daemon")
     }
 
     pub fn cancel_shutdown() -> Command {
@@ -88,6 +93,12 @@ pub async fn version(client: &proc_control::Client) -> CommandResult<()> {
 
 pub async fn offline(client: &proc_control::Client) -> CommandResult<()> {
     let req = client.offline_request();
+    let rsp = req.send().promise.await?;
+    parse_operation_result(rsp.get()?.get_result()?)
+}
+
+pub async fn reload(client: &proc_control::Client) -> CommandResult<()> {
+    let req = client.reload_request();
     let rsp = req.send().promise.await?;
     parse_operation_result(rsp.get()?.get_result()?)
 }

--- a/g3proxy/proto/schema/proc.capnp
+++ b/g3proxy/proto/schema/proc.capnp
@@ -12,6 +12,7 @@ interface ProcControl {
 
   version @0 () -> (version :Text);
   offline @1 () -> (result :Types.OperationResult);
+  reload @22 () -> (result :Types.OperationResult);
   cancelShutdown @20 () -> (result :Types.OperationResult);
   releaseController @21 () -> (result :Types.OperationResult);
 

--- a/g3proxy/src/control/bridge/mod.rs
+++ b/g3proxy/src/control/bridge/mod.rs
@@ -5,5 +5,5 @@
 
 mod reload;
 pub(super) use reload::{
-    reload_auditor, reload_escaper, reload_resolver, reload_server, reload_user_group,
+    reload, reload_auditor, reload_escaper, reload_resolver, reload_server, reload_user_group,
 };

--- a/g3proxy/src/control/bridge/reload.rs
+++ b/g3proxy/src/control/bridge/reload.rs
@@ -8,6 +8,14 @@ use anyhow::anyhow;
 use g3_types::metrics::NodeName;
 use g3_yaml::YamlDocPosition;
 
+pub(in crate::control) async fn reload() -> anyhow::Result<()> {
+    g3_daemon::runtime::main_handle()
+        .ok_or(anyhow!("unable to get main runtime handle"))?
+        .spawn(crate::signal::reload())
+        .await
+        .map_err(|e| anyhow!("failed to spawn reload task: {e}"))?
+}
+
 macro_rules! impl_reload {
     ($f:ident, $m:tt) => {
         pub(in crate::control) async fn $f(

--- a/g3proxy/src/control/capnp/proc.rs
+++ b/g3proxy/src/control/capnp/proc.rs
@@ -38,6 +38,16 @@ impl proc_control::Server for ProcControlImpl {
         Ok(())
     }
 
+    async fn reload(
+        self: Rc<Self>,
+        _params: proc_control::ReloadParams,
+        mut results: proc_control::ReloadResults,
+    ) -> capnp::Result<()> {
+        let r = crate::control::bridge::reload().await;
+        set_operation_result(results.get().init_result(), r);
+        Ok(())
+    }
+
     async fn cancel_shutdown(
         self: Rc<Self>,
         _params: proc_control::CancelShutdownParams,

--- a/g3proxy/src/signal.rs
+++ b/g3proxy/src/signal.rs
@@ -3,39 +3,53 @@
  * Copyright 2023-2025 ByteDance and/or its affiliates.
  */
 
-use log::{error, info, warn};
+use anyhow::Context;
+use log::{info, warn};
 use tokio::sync::Mutex;
 
 use g3_daemon::signal::AsyncSignalAction;
 
 static RELOAD_MUTEX: Mutex<()> = Mutex::const_new(());
 
-async fn do_reload() {
+pub(super) async fn reload() -> anyhow::Result<()> {
     let _guard = RELOAD_MUTEX.lock().await;
     info!("reloading config");
 
-    if let Err(e) = crate::config::reload().await {
-        warn!("error reloading config: {e:?}");
-        warn!("reload aborted");
+    match reload_locked().await {
+        Ok(_) => {
+            info!("reload finished");
+            Ok(())
+        }
+        Err(e) => {
+            warn!("reload error: {e:?}");
+            warn!("reload aborted");
+            Err(e)
+        }
     }
+}
 
-    if let Err(e) = crate::resolve::spawn_all().await {
-        error!("failed to reload all resolvers: {e:?}");
-    }
-    if let Err(e) = crate::escape::load_all().await {
-        error!("failed to reload all escapers: {e:?}");
-    }
-    if let Err(e) = crate::auth::load_all().await {
-        error!("failed to reload all user groups: {e:?}");
-    }
-    if let Err(e) = crate::audit::load_all().await {
-        error!("failed to reload all auditors: {e:?}");
-    }
-    if let Err(e) = crate::serve::spawn_all().await {
-        error!("failed to reload all servers: {e:?}");
-    }
+async fn reload_locked() -> anyhow::Result<()> {
+    crate::config::reload()
+        .await
+        .context("failed to reload config")?;
 
-    info!("reload finished");
+    crate::resolve::spawn_all()
+        .await
+        .context("failed to reload all resolvers")?;
+    crate::escape::load_all()
+        .await
+        .context("failed to reload all escapers")?;
+    crate::auth::load_all()
+        .await
+        .context("failed to reload all user groups")?;
+    crate::audit::load_all()
+        .await
+        .context("failed to reload all auditors")?;
+    crate::serve::spawn_all()
+        .await
+        .context("failed to reload all servers")?;
+
+    Ok(())
 }
 
 #[derive(Clone, Copy)]
@@ -47,30 +61,37 @@ impl AsyncSignalAction for QuitAction {
     }
 }
 
-#[allow(unused)]
-#[derive(Clone, Copy)]
-struct OfflineAction {}
+#[cfg(unix)]
+mod unix {
+    use g3_daemon::signal::AsyncSignalAction;
 
-impl AsyncSignalAction for OfflineAction {
-    async fn run(&self) {
-        g3_daemon::control::quit::start_graceful_shutdown().await
+    #[derive(Clone, Copy)]
+    struct OfflineAction {}
+
+    impl AsyncSignalAction for OfflineAction {
+        async fn run(&self) {
+            g3_daemon::control::quit::start_graceful_shutdown().await
+        }
     }
-}
 
-#[allow(unused)]
-#[derive(Clone, Copy)]
-struct ReloadAction {}
+    #[derive(Clone, Copy)]
+    struct ReloadAction {}
 
-impl AsyncSignalAction for ReloadAction {
-    async fn run(&self) {
-        do_reload().await
+    impl AsyncSignalAction for ReloadAction {
+        async fn run(&self) {
+            let _ = super::reload().await;
+        }
+    }
+
+    pub(super) fn register() -> anyhow::Result<()> {
+        g3_daemon::signal::register_reload(ReloadAction {})?;
+        g3_daemon::signal::register_offline(OfflineAction {})?;
+        Ok(())
     }
 }
 
 pub fn register() -> anyhow::Result<()> {
     #[cfg(unix)]
-    g3_daemon::signal::register_reload(ReloadAction {})?;
-    #[cfg(unix)]
-    g3_daemon::signal::register_offline(OfflineAction {})?;
+    unix::register()?;
     g3_daemon::signal::register_quit(QuitAction {})
 }

--- a/g3proxy/utils/ctl/src/main.rs
+++ b/g3proxy/utils/ctl/src/main.rs
@@ -23,6 +23,7 @@ fn build_cli_args() -> Command {
         .append_daemon_ctl_args()
         .subcommand(proc::commands::version())
         .subcommand(proc::commands::offline())
+        .subcommand(proc::commands::reload())
         .subcommand(proc::commands::cancel_shutdown())
         .subcommand(proc::commands::force_quit())
         .subcommand(proc::commands::force_quit_all())
@@ -63,6 +64,7 @@ async fn main() -> anyhow::Result<()> {
             match subcommand {
                 proc::COMMAND_VERSION => proc::version(&proc_control).await,
                 proc::COMMAND_OFFLINE => proc::offline(&proc_control).await,
+                proc::COMMAND_RELOAD => proc::reload(&proc_control).await,
                 proc::COMMAND_CANCEL_SHUTDOWN => proc::cancel_shutdown(&proc_control).await,
                 proc::COMMAND_FORCE_QUIT => proc::force_quit(&proc_control, args).await,
                 proc::COMMAND_FORCE_QUIT_ALL => proc::force_quit_all(&proc_control).await,

--- a/g3proxy/utils/ctl/src/proc.rs
+++ b/g3proxy/utils/ctl/src/proc.rs
@@ -17,6 +17,7 @@ use crate::common::{parse_fetch_result, parse_operation_result};
 
 pub const COMMAND_VERSION: &str = "version";
 pub const COMMAND_OFFLINE: &str = "offline";
+pub const COMMAND_RELOAD: &str = "reload";
 pub const COMMAND_CANCEL_SHUTDOWN: &str = "cancel-shutdown";
 
 pub const COMMAND_FORCE_QUIT: &str = "force-quit";
@@ -49,6 +50,10 @@ pub mod commands {
 
     pub fn offline() -> Command {
         Command::new(COMMAND_OFFLINE).about("Put this daemon into offline mode")
+    }
+
+    pub fn reload() -> Command {
+        Command::new(COMMAND_RELOAD).about("Reload the daemon")
     }
 
     pub fn cancel_shutdown() -> Command {
@@ -116,6 +121,12 @@ pub async fn version(client: &proc_control::Client) -> CommandResult<()> {
 
 pub async fn offline(client: &proc_control::Client) -> CommandResult<()> {
     let req = client.offline_request();
+    let rsp = req.send().promise.await?;
+    parse_operation_result(rsp.get()?.get_result()?)
+}
+
+pub async fn reload(client: &proc_control::Client) -> CommandResult<()> {
+    let req = client.reload_request();
     let rsp = req.send().promise.await?;
     parse_operation_result(rsp.get()?.get_result()?)
 }

--- a/g3statsd/proto/schema/proc.capnp
+++ b/g3statsd/proto/schema/proc.capnp
@@ -7,6 +7,7 @@ interface ProcControl {
 
   version @0 () -> (version :Text);
   offline @1 () -> (result :Types.OperationResult);
+  reload @10 () -> (result :Types.OperationResult);
   cancelShutdown @2 () -> (result :Types.OperationResult);
   releaseController @3 () -> (result :Types.OperationResult);
 

--- a/g3statsd/src/control/bridge/mod.rs
+++ b/g3statsd/src/control/bridge/mod.rs
@@ -4,4 +4,4 @@
  */
 
 mod reload;
-pub(super) use reload::{reload_collector, reload_exporter, reload_importer};
+pub(super) use reload::{reload, reload_collector, reload_exporter, reload_importer};

--- a/g3statsd/src/control/bridge/reload.rs
+++ b/g3statsd/src/control/bridge/reload.rs
@@ -8,6 +8,14 @@ use anyhow::anyhow;
 use g3_types::metrics::NodeName;
 use g3_yaml::YamlDocPosition;
 
+pub(in crate::control) async fn reload() -> anyhow::Result<()> {
+    g3_daemon::runtime::main_handle()
+        .ok_or(anyhow!("unable to get main runtime handle"))?
+        .spawn(crate::signal::reload())
+        .await
+        .map_err(|e| anyhow!("failed to spawn reload task: {e}"))?
+}
+
 macro_rules! impl_reload {
     ($f:ident, $m:tt) => {
         pub(in crate::control) async fn $f(

--- a/g3statsd/src/control/capnp/proc.rs
+++ b/g3statsd/src/control/capnp/proc.rs
@@ -32,6 +32,16 @@ impl proc_control::Server for ProcControlImpl {
         Ok(())
     }
 
+    async fn reload(
+        self: Rc<Self>,
+        _params: proc_control::ReloadParams,
+        mut results: proc_control::ReloadResults,
+    ) -> capnp::Result<()> {
+        let r = crate::control::bridge::reload().await;
+        set_operation_result(results.get().init_result(), r);
+        Ok(())
+    }
+
     async fn cancel_shutdown(
         self: Rc<Self>,
         _params: proc_control::CancelShutdownParams,

--- a/g3statsd/src/signal.rs
+++ b/g3statsd/src/signal.rs
@@ -3,31 +3,45 @@
  * Copyright 2025 ByteDance and/or its affiliates.
  */
 
-use log::{error, info, warn};
+use anyhow::Context;
+use log::{info, warn};
 use tokio::sync::Mutex;
 
 use g3_daemon::signal::AsyncSignalAction;
 
 static RELOAD_MUTEX: Mutex<()> = Mutex::const_new(());
 
-async fn do_reload() {
+pub(super) async fn reload() -> anyhow::Result<()> {
     let _guard = RELOAD_MUTEX.lock().await;
     info!("reloading config");
 
-    if let Err(e) = crate::config::reload().await {
-        warn!("error reloading config: {e:?}");
-        warn!("reload aborted");
+    match reload_locked().await {
+        Ok(_) => {
+            info!("reload finished");
+            Ok(())
+        }
+        Err(e) => {
+            warn!("reload error: {e:?}");
+            warn!("reload aborted");
+            Err(e)
+        }
     }
+}
 
-    if let Err(e) = crate::collect::load_all().await {
-        error!("failed to reload all collectors: {e}");
-    }
-    if let Err(e) = crate::import::spawn_all().await {
-        error!("failed to reload all importers: {e}");
-    }
+async fn reload_locked() -> anyhow::Result<()> {
+    crate::config::reload()
+        .await
+        .context("failed to reload config")?;
+
+    crate::collect::load_all()
+        .await
+        .context("failed to reload all collectors")?;
+    crate::import::spawn_all()
+        .await
+        .context("failed to reload all importers")?;
     // TODO reload all exporters
 
-    info!("reload finished");
+    Ok(())
 }
 
 #[derive(Clone, Copy)]
@@ -39,30 +53,37 @@ impl AsyncSignalAction for QuitAction {
     }
 }
 
-#[allow(unused)]
-#[derive(Clone, Copy)]
-struct OfflineAction {}
+#[cfg(unix)]
+mod unix {
+    use g3_daemon::signal::AsyncSignalAction;
 
-impl AsyncSignalAction for OfflineAction {
-    async fn run(&self) {
-        g3_daemon::control::quit::start_graceful_shutdown().await;
+    #[derive(Clone, Copy)]
+    struct OfflineAction {}
+
+    impl AsyncSignalAction for OfflineAction {
+        async fn run(&self) {
+            g3_daemon::control::quit::start_graceful_shutdown().await;
+        }
     }
-}
 
-#[allow(unused)]
-#[derive(Clone, Copy)]
-struct ReloadAction {}
+    #[derive(Clone, Copy)]
+    struct ReloadAction {}
 
-impl AsyncSignalAction for ReloadAction {
-    async fn run(&self) {
-        do_reload().await
+    impl AsyncSignalAction for ReloadAction {
+        async fn run(&self) {
+            let _ = super::reload().await;
+        }
+    }
+
+    pub(super) fn register() -> anyhow::Result<()> {
+        g3_daemon::signal::register_reload(ReloadAction {})?;
+        g3_daemon::signal::register_offline(OfflineAction {})?;
+        Ok(())
     }
 }
 
 pub fn register() -> anyhow::Result<()> {
     #[cfg(unix)]
-    g3_daemon::signal::register_reload(ReloadAction {})?;
-    #[cfg(unix)]
-    g3_daemon::signal::register_offline(OfflineAction {})?;
+    unix::register()?;
     g3_daemon::signal::register_quit(QuitAction {})
 }

--- a/g3statsd/utils/ctl/src/main.rs
+++ b/g3statsd/utils/ctl/src/main.rs
@@ -18,6 +18,7 @@ fn build_cli_args() -> Command {
         .append_daemon_ctl_args()
         .subcommand(proc::commands::version())
         .subcommand(proc::commands::offline())
+        .subcommand(proc::commands::reload())
         .subcommand(proc::commands::cancel_shutdown())
         .subcommand(proc::commands::list())
         .subcommand(proc::commands::reload_importer())
@@ -50,6 +51,7 @@ async fn main() -> anyhow::Result<()> {
             match subcommand {
                 proc::COMMAND_VERSION => proc::version(&proc_control).await,
                 proc::COMMAND_OFFLINE => proc::offline(&proc_control).await,
+                proc::COMMAND_RELOAD => proc::reload(&proc_control).await,
                 proc::COMMAND_CANCEL_SHUTDOWN => proc::cancel_shutdown(&proc_control).await,
                 proc::COMMAND_LIST => proc::list(&proc_control, args).await,
                 proc::COMMAND_RELOAD_IMPORTER => proc::reload_importer(&proc_control, args).await,

--- a/g3statsd/utils/ctl/src/proc.rs
+++ b/g3statsd/utils/ctl/src/proc.rs
@@ -13,6 +13,7 @@ use crate::common::parse_operation_result;
 
 pub const COMMAND_VERSION: &str = "version";
 pub const COMMAND_OFFLINE: &str = "offline";
+pub const COMMAND_RELOAD: &str = "reload";
 pub const COMMAND_CANCEL_SHUTDOWN: &str = "cancel-shutdown";
 
 pub const COMMAND_LIST: &str = "list";
@@ -38,6 +39,10 @@ pub mod commands {
 
     pub fn offline() -> Command {
         Command::new(COMMAND_OFFLINE).about("Put this daemon into offline mode")
+    }
+
+    pub fn reload() -> Command {
+        Command::new(COMMAND_RELOAD).about("Reload the daemon")
     }
 
     pub fn cancel_shutdown() -> Command {
@@ -83,6 +88,12 @@ pub async fn version(client: &proc_control::Client) -> CommandResult<()> {
 
 pub async fn offline(client: &proc_control::Client) -> CommandResult<()> {
     let req = client.offline_request();
+    let rsp = req.send().promise.await?;
+    parse_operation_result(rsp.get()?.get_result()?)
+}
+
+pub async fn reload(client: &proc_control::Client) -> CommandResult<()> {
+    let req = client.reload_request();
     let rsp = req.send().promise.await?;
     parse_operation_result(rsp.get()?.get_result()?)
 }

--- a/g3tiles/proto/schema/proc.capnp
+++ b/g3tiles/proto/schema/proc.capnp
@@ -11,6 +11,7 @@ interface ProcControl {
 
   version @0 () -> (version :Text);
   offline @1 () -> (result :Types.OperationResult);
+  reload @14 () -> (result :Types.OperationResult);
   cancelShutdown @11 () -> (result :Types.OperationResult);
   releaseController @12 () -> (result :Types.OperationResult);
 

--- a/g3tiles/src/control/bridge/mod.rs
+++ b/g3tiles/src/control/bridge/mod.rs
@@ -4,4 +4,4 @@
  */
 
 mod reload;
-pub(super) use reload::{reload_backend, reload_discover, reload_server};
+pub(super) use reload::{reload, reload_backend, reload_discover, reload_server};

--- a/g3tiles/src/control/bridge/reload.rs
+++ b/g3tiles/src/control/bridge/reload.rs
@@ -8,6 +8,14 @@ use anyhow::anyhow;
 use g3_types::metrics::NodeName;
 use g3_yaml::YamlDocPosition;
 
+pub(in crate::control) async fn reload() -> anyhow::Result<()> {
+    g3_daemon::runtime::main_handle()
+        .ok_or(anyhow!("unable to get main runtime handle"))?
+        .spawn(crate::signal::reload())
+        .await
+        .map_err(|e| anyhow!("failed to spawn reload task: {e}"))?
+}
+
 macro_rules! impl_reload {
     ($f:ident, $m:tt) => {
         pub(in crate::control) async fn $f(

--- a/g3tiles/src/control/capnp/proc.rs
+++ b/g3tiles/src/control/capnp/proc.rs
@@ -36,6 +36,16 @@ impl proc_control::Server for ProcControlImpl {
         Ok(())
     }
 
+    async fn reload(
+        self: Rc<Self>,
+        _params: proc_control::ReloadParams,
+        mut results: proc_control::ReloadResults,
+    ) -> capnp::Result<()> {
+        let r = crate::control::bridge::reload().await;
+        set_operation_result(results.get().init_result(), r);
+        Ok(())
+    }
+
     async fn cancel_shutdown(
         self: Rc<Self>,
         _params: proc_control::CancelShutdownParams,

--- a/g3tiles/src/signal.rs
+++ b/g3tiles/src/signal.rs
@@ -3,33 +3,47 @@
  * Copyright 2023-2025 ByteDance and/or its affiliates.
  */
 
-use log::{error, info, warn};
+use anyhow::Context;
+use log::{info, warn};
 use tokio::sync::Mutex;
 
 use g3_daemon::signal::AsyncSignalAction;
 
 static RELOAD_MUTEX: Mutex<()> = Mutex::const_new(());
 
-async fn do_reload() {
+pub(super) async fn reload() -> anyhow::Result<()> {
     let _guard = RELOAD_MUTEX.lock().await;
     info!("reloading config");
 
-    if let Err(e) = crate::config::reload().await {
-        warn!("error reloading config: {e:?}");
-        warn!("reload aborted");
+    match reload_locked().await {
+        Ok(_) => {
+            info!("reload finished");
+            Ok(())
+        }
+        Err(e) => {
+            warn!("reload error: {e:?}");
+            warn!("reload aborted");
+            Err(e)
+        }
     }
+}
 
-    if let Err(e) = crate::discover::load_all().await {
-        error!("failed to reload all discovers: {e}");
-    }
-    if let Err(e) = crate::backend::load_all().await {
-        error!("failed to reload all backends: {e}");
-    }
-    if let Err(e) = crate::serve::spawn_all().await {
-        error!("failed to reload all servers: {e:?}");
-    }
+async fn reload_locked() -> anyhow::Result<()> {
+    crate::config::reload()
+        .await
+        .context("failed to reload config")?;
 
-    info!("reload finished");
+    crate::discover::load_all()
+        .await
+        .context("failed to reload all discovers")?;
+    crate::backend::load_all()
+        .await
+        .context("failed to reload all backends")?;
+    crate::serve::spawn_all()
+        .await
+        .context("failed to reload all servers")?;
+
+    Ok(())
 }
 
 #[derive(Clone, Copy)]
@@ -41,30 +55,37 @@ impl AsyncSignalAction for QuitAction {
     }
 }
 
-#[allow(unused)]
-#[derive(Clone, Copy)]
-struct OfflineAction {}
+#[cfg(unix)]
+mod unix {
+    use g3_daemon::signal::AsyncSignalAction;
 
-impl AsyncSignalAction for OfflineAction {
-    async fn run(&self) {
-        g3_daemon::control::quit::start_graceful_shutdown().await;
+    #[derive(Clone, Copy)]
+    struct OfflineAction {}
+
+    impl AsyncSignalAction for OfflineAction {
+        async fn run(&self) {
+            g3_daemon::control::quit::start_graceful_shutdown().await;
+        }
     }
-}
 
-#[allow(unused)]
-#[derive(Clone, Copy)]
-struct ReloadAction {}
+    #[derive(Clone, Copy)]
+    struct ReloadAction {}
 
-impl AsyncSignalAction for ReloadAction {
-    async fn run(&self) {
-        do_reload().await
+    impl AsyncSignalAction for ReloadAction {
+        async fn run(&self) {
+            let _ = super::reload().await;
+        }
+    }
+
+    pub(super) fn register() -> anyhow::Result<()> {
+        g3_daemon::signal::register_reload(ReloadAction {})?;
+        g3_daemon::signal::register_offline(OfflineAction {})?;
+        Ok(())
     }
 }
 
 pub fn register() -> anyhow::Result<()> {
     #[cfg(unix)]
-    g3_daemon::signal::register_reload(ReloadAction {})?;
-    #[cfg(unix)]
-    g3_daemon::signal::register_offline(OfflineAction {})?;
+    unix::register()?;
     g3_daemon::signal::register_quit(QuitAction {})
 }

--- a/g3tiles/utils/ctl/src/main.rs
+++ b/g3tiles/utils/ctl/src/main.rs
@@ -21,6 +21,7 @@ fn build_cli_args() -> Command {
         .append_daemon_ctl_args()
         .subcommand(proc::commands::version())
         .subcommand(proc::commands::offline())
+        .subcommand(proc::commands::reload())
         .subcommand(proc::commands::cancel_shutdown())
         .subcommand(proc::commands::force_quit())
         .subcommand(proc::commands::force_quit_all())
@@ -57,6 +58,7 @@ async fn main() -> anyhow::Result<()> {
             match subcommand {
                 proc::COMMAND_VERSION => proc::version(&proc_control).await,
                 proc::COMMAND_OFFLINE => proc::offline(&proc_control).await,
+                proc::COMMAND_RELOAD => proc::reload(&proc_control).await,
                 proc::COMMAND_CANCEL_SHUTDOWN => proc::cancel_shutdown(&proc_control).await,
                 proc::COMMAND_FORCE_QUIT => proc::force_quit(&proc_control, args).await,
                 proc::COMMAND_FORCE_QUIT_ALL => proc::force_quit_all(&proc_control).await,

--- a/g3tiles/utils/ctl/src/proc.rs
+++ b/g3tiles/utils/ctl/src/proc.rs
@@ -15,6 +15,7 @@ use crate::common::{parse_fetch_result, parse_operation_result};
 
 pub const COMMAND_VERSION: &str = "version";
 pub const COMMAND_OFFLINE: &str = "offline";
+pub const COMMAND_RELOAD: &str = "reload";
 pub const COMMAND_CANCEL_SHUTDOWN: &str = "cancel-shutdown";
 
 pub const COMMAND_FORCE_QUIT: &str = "force-quit";
@@ -43,6 +44,10 @@ pub mod commands {
 
     pub fn offline() -> Command {
         Command::new(COMMAND_OFFLINE).about("Put this daemon into offline mode")
+    }
+
+    pub fn reload() -> Command {
+        Command::new(COMMAND_RELOAD).about("Reload the daemon")
     }
 
     pub fn cancel_shutdown() -> Command {
@@ -98,6 +103,12 @@ pub async fn version(client: &proc_control::Client) -> CommandResult<()> {
 
 pub async fn offline(client: &proc_control::Client) -> CommandResult<()> {
     let req = client.offline_request();
+    let rsp = req.send().promise.await?;
+    parse_operation_result(rsp.get()?.get_result()?)
+}
+
+pub async fn reload(client: &proc_control::Client) -> CommandResult<()> {
+    let req = client.reload_request();
     let rsp = req.send().promise.await?;
     parse_operation_result(rsp.get()?.get_result()?)
 }


### PR DESCRIPTION
Fixes #1116

## Summary

- add a whole-daemon `reload` RPC and ctl subcommand for `g3proxy`, `g3keymess`, `g3statsd`, and `g3tiles`
- make the reload path callable on Windows so the configuration reload helpers are no longer dead code
- keep reload/offline signal registration and action types inside `cfg(unix)` modules
- serialize reloads with the existing mutex and return operation errors to ctl callers

This follows the pattern in VEY-OSS/vey commit `52fd8fc8a582373789415fdd1b8985a410f9381a` referenced in #1116.

## Validation

- `git diff --check`
- reviewed all four Cap'n Proto schemas, servers, bridges, signal modules, and ctl clients as one consistent change

The local Windows environment does not have Rust or Cap'n Proto installed, so the repository's Windows and Unix CI jobs are the compile-validation gate.
